### PR TITLE
:ghost: improve CI

### DIFF
--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -27,12 +27,13 @@ jobs:
           expected_file=./test-data/analysis-output.yaml
           actual_file=./output/output.yaml
           function filter_and_sort() {
-            yq e 'del(.[].skipped) | del(.[].unmatched)' $1 > /tmp/filtered
-            yq e '.[]?.violations |= (. | to_entries | sort_by(.key) | from_entries)' /tmp/filtered > /tmp/sorted
-            yq e '.[]?.violations[]?.incidents |= sort_by(.uri)' /tmp/sorted > $1 
+            yq e 'del(.[].skipped) | del(.[].unmatched)' $1 \
+              | yq e '.[]?.violations |= (. | to_entries | sort_by(.key) | from_entries)' \
+              | yq e '.[]?.violations[]?.incidents |= sort_by(.uri)' \
+              | yq e '.[] | (.tags // []) |= sort'
           }
-          filter_and_sort $expected_file
-          filter_and_sort $actual_file
+          filter_and_sort $expected_file > $expected_file
+          filter_and_sort $actual_file > $actual_file
           diff $expected_file $actual_file
 
       - name: Fail if dependencies output does not match expected

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -28,7 +28,8 @@ jobs:
           actual_file=./output/output.yaml
           function filter_and_sort() {
             yq e 'del(.[].skipped) | del(.[].unmatched)' $1 > /tmp/filtered
-            yq e '(.[] | select(.violations != null) | .violations |= (. | to_entries | sort_by(.key) | from_entries))' /tmp/filtered > $1
+            yq e '.[]?.violations |= (. | to_entries | sort_by(.key) | from_entries)' /tmp/filtered > /tmp/sorted
+            yq e '.[]?.violations[]?.incidents |= sort_by(.uri)' /tmp/sorted > $1 
           }
           filter_and_sort $expected_file
           filter_and_sort $actual_file

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -26,9 +26,13 @@ jobs:
         run: |
           expected_file=./test-data/analysis-output.yaml
           actual_file=./output/output.yaml
-          sed 's/^[ \t-]*//' $expected_file | sort -s > /tmp/expected_file
-          sed 's/^[ \t-]*//' $actual_file | sort -s > /tmp/actual_file
-          diff /tmp/expected_file /tmp/actual_file || diff $expected_file $actual_file
+          function filter_and_sort() {
+            yq e 'del(.[].skipped) | del(.[].unmatched)' $1 > /tmp/filtered
+            yq e '(.[] | select(.violations != null) | .violations |= (. | to_entries | sort_by(.key) | from_entries))' /tmp/filtered > $1
+          }
+          filter_and_sort $expected_file
+          filter_and_sort $actual_file
+          diff $expected_file $actual_file
 
       - name: Fail if dependencies output does not match expected
         run: |


### PR DESCRIPTION
In our current script, we compare the full output which contains skipped and unmatched rules. This list changes everytime there are updates to rulesets. With this PR, we will only check if there's diffeerences in created issues and tags and nothing else.