### PR TITLE
:bug: Fix no-cleanup option, disable analysis logs to stdout

### DIFF
--- a/cmd/openrewrite.go
+++ b/cmd/openrewrite.go
@@ -18,11 +18,13 @@ type openRewriteCommand struct {
 	goal        string
 	miscOpts    string
 	log         logr.Logger
+	cleanup     bool
 }
 
 func NewOpenRewriteCommand(log logr.Logger) *cobra.Command {
 	openRewriteCmd := &openRewriteCommand{
-		log: log,
+		log:     log,
+		cleanup: true,
 	}
 
 	openRewriteCommand := &cobra.Command{
@@ -36,6 +38,9 @@ func NewOpenRewriteCommand(log logr.Logger) *cobra.Command {
 			}
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if val, err := cmd.Flags().GetBool(noCleanupFlag); err == nil {
+				openRewriteCmd.cleanup = !val
+			}
 			err := openRewriteCmd.Validate()
 			if err != nil {
 				log.Error(err, "failed validating input args")
@@ -144,6 +149,7 @@ func (o *openRewriteCommand) Run(ctx context.Context) error {
 		WithEntrypointBin("/usr/bin/mvn"),
 		WithVolumes(volumes),
 		WithWorkDir(InputPath),
+		WithCleanup(o.cleanup),
 	)
 	if err != nil {
 		o.log.V(1).Error(err, "error running openrewrite")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -15,6 +15,7 @@ import (
 
 const (
 	noCleanupFlag = "no-cleanup"
+	logLevelFlag  = "log-level"
 )
 
 var logLevel uint32
@@ -36,7 +37,7 @@ var rootCmd = &cobra.Command{
 }
 
 func init() {
-	rootCmd.PersistentFlags().Uint32Var(&logLevel, "log-level", 4, "log level")
+	rootCmd.PersistentFlags().Uint32Var(&logLevel, logLevelFlag, 4, "log level")
 	rootCmd.PersistentFlags().BoolVar(&noCleanup, noCleanupFlag, false, "do not cleanup temporary resources")
 
 	logrusLog = logrus.New()


### PR DESCRIPTION
Fixes #92 
Fixes #55

* Disables analysis logs to stdout 
* Passes down log level to analyzer command
* Adds log files for all commands and prints logs there
* Replaces deprecated ioutil.WriteFile with os.WriteFile