### PR TITLE
:bug: adding entrypoint to copy source from mount to container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,5 +40,6 @@ COPY --from=rulesets /rulesets/default/generated /opt/rulesets
 COPY --from=rulesets /windup-rulesets/rules/rules-reviewed/openrewrite /opt/openrewrite
 COPY --from=static-report /usr/bin/js-bundle-generator /usr/local/bin
 COPY --from=static-report /usr/local/static-report /usr/local/static-report
+COPY entrypoint.sh /usr/bin/entrypoint.sh
 
 ENTRYPOINT ["kantra"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -x
+
+cp -r /opt/input/source /tmp/source-code
+sed -i 's|/opt/input/source|/tmp/source-code|g' /opt/input/config/settings.json
+/usr/bin/konveyor-analyzer "$@" 
+sed -i 's|/tmp/source-code|/opt/input/source|g' /opt/input/config/settings.json

--- a/test-data/analysis-output.yaml
+++ b/test-data/analysis-output.yaml
@@ -240,7 +240,7 @@
       - konveyor.io/target=cloud-readiness
       - discovery
       incidents:
-      - uri: file:///opt/input/source/target/classes/persistence.properties
+      - uri: file:///tmp/source-code/target/classes/persistence.properties
         message: When migrating environments, hard-coded IP addresses may need to be modified or eliminated.
         codeSnip: |2
             1  jdbc.driverClassName=oracle.jdbc.driver.OracleDriver
@@ -252,7 +252,7 @@
         lineNumber: 2
         variables:
           matchingText: 169.60.225.216
-      - uri: file:///opt/input/source/src/main/resources/persistence.properties
+      - uri: file:///tmp/source-code/src/main/resources/persistence.properties
         message: When migrating environments, hard-coded IP addresses may need to be modified or eliminated.
         codeSnip: |2
             1  jdbc.driverClassName=oracle.jdbc.driver.OracleDriver


### PR DESCRIPTION
Basically the biggest issue with running on Mac and windows is the virtualization layer and file i/o over that virtualization. 

Podman is currently working on this; until that is finished, copying the source to the container to reduce file i/o speeds up the process by quite a bit.

I am seeing 5-minute runs after this change for analyzing `coolstuff-javaee` from 24min with the same output.