### PR TITLE
:sparkles: Add proxy option

### DIFF
--- a/cmd/analyze.go
+++ b/cmd/analyze.go
@@ -61,7 +61,8 @@ type analyzeCommand struct {
 	rules                 []string
 	jaegerEndpoint        string
 	enableDefaultRulesets bool
-	proxy                 string
+	httpProxy             string
+	httpsProxy            string
 	noProxy               string
 
 	// tempDirs list of temporary dirs created, used for cleanup
@@ -162,8 +163,9 @@ func NewAnalyzeCmd(log logr.Logger) *cobra.Command {
 	analyzeCommand.Flags().BoolVar(&analyzeCmd.overwrite, "overwrite", false, "overwrite output directory")
 	analyzeCommand.Flags().StringVar(&analyzeCmd.jaegerEndpoint, "jaeger-endpoint", "", "jaeger endpoint to collect traces")
 	analyzeCommand.Flags().BoolVar(&analyzeCmd.enableDefaultRulesets, "enable-default-rulesets", true, "run default rulesets with analysis")
-	analyzeCommand.Flags().StringVar(&analyzeCmd.proxy, "proxy", "", "HTTP&HTTPS proxy string URL")
-	analyzeCommand.Flags().StringVar(&analyzeCmd.noProxy, "no-proxy", "", "proxy excluded URLs (relevant only with `proxy`)")
+	analyzeCommand.Flags().StringVar(&analyzeCmd.httpProxy, "http-proxy", os.Getenv("http_proxy"), "HTTP proxy string URL")
+	analyzeCommand.Flags().StringVar(&analyzeCmd.httpsProxy, "https-proxy", os.Getenv("https_proxy"), "HTTPS proxy string URL")
+	analyzeCommand.Flags().StringVar(&analyzeCmd.noProxy, "no-proxy", os.Getenv("no_proxy"), "proxy excluded URLs (relevant only with proxy)")
 
 	return analyzeCommand
 }
@@ -464,10 +466,10 @@ func (a *analyzeCommand) getConfigVolumes() (map[string]string, error) {
 	}
 
 	// Set proxy to providers
-	if a.proxy != "" {
+	if a.httpProxy != "" || a.httpsProxy != "" {
 		proxy := provider.Proxy{
-			HTTPProxy: a.proxy,
-			HTTPSProxy: a.proxy,
+			HTTPProxy: a.httpProxy,
+			HTTPSProxy: a.httpsProxy,
 			NoProxy: a.noProxy,
 		}
 		for i := range provConfig {

--- a/cmd/analyze.go
+++ b/cmd/analyze.go
@@ -62,6 +62,7 @@ type analyzeCommand struct {
 	jaegerEndpoint        string
 	enableDefaultRulesets bool
 	proxy                 string
+	noProxy               string
 
 	// tempDirs list of temporary dirs created, used for cleanup
 	tempDirs []string
@@ -162,6 +163,7 @@ func NewAnalyzeCmd(log logr.Logger) *cobra.Command {
 	analyzeCommand.Flags().StringVar(&analyzeCmd.jaegerEndpoint, "jaeger-endpoint", "", "jaeger endpoint to collect traces")
 	analyzeCommand.Flags().BoolVar(&analyzeCmd.enableDefaultRulesets, "enable-default-rulesets", true, "run default rulesets with analysis")
 	analyzeCommand.Flags().StringVar(&analyzeCmd.proxy, "proxy", "", "HTTP&HTTPS proxy string URL")
+	analyzeCommand.Flags().StringVar(&analyzeCmd.noProxy, "no-proxy", "", "proxy excluded URLs (relevant only with `proxy`)")
 
 	return analyzeCommand
 }
@@ -466,6 +468,7 @@ func (a *analyzeCommand) getConfigVolumes() (map[string]string, error) {
 		proxy := provider.Proxy{
 			HTTPProxy: a.proxy,
 			HTTPSProxy: a.proxy,
+			NoProxy: a.noProxy,
 		}
 		for i := range provConfig {
 			provConfig[i].Proxy = &proxy

--- a/cmd/analyze.go
+++ b/cmd/analyze.go
@@ -163,9 +163,9 @@ func NewAnalyzeCmd(log logr.Logger) *cobra.Command {
 	analyzeCommand.Flags().BoolVar(&analyzeCmd.overwrite, "overwrite", false, "overwrite output directory")
 	analyzeCommand.Flags().StringVar(&analyzeCmd.jaegerEndpoint, "jaeger-endpoint", "", "jaeger endpoint to collect traces")
 	analyzeCommand.Flags().BoolVar(&analyzeCmd.enableDefaultRulesets, "enable-default-rulesets", true, "run default rulesets with analysis")
-	analyzeCommand.Flags().StringVar(&analyzeCmd.httpProxy, "http-proxy", os.Getenv("http_proxy"), "HTTP proxy string URL")
-	analyzeCommand.Flags().StringVar(&analyzeCmd.httpsProxy, "https-proxy", os.Getenv("https_proxy"), "HTTPS proxy string URL")
-	analyzeCommand.Flags().StringVar(&analyzeCmd.noProxy, "no-proxy", os.Getenv("no_proxy"), "proxy excluded URLs (relevant only with proxy)")
+	analyzeCommand.Flags().StringVar(&analyzeCmd.httpProxy, "http-proxy", loadEnvInsensitive("http_proxy"), "HTTP proxy string URL")
+	analyzeCommand.Flags().StringVar(&analyzeCmd.httpsProxy, "https-proxy", loadEnvInsensitive("https_proxy"), "HTTPS proxy string URL")
+	analyzeCommand.Flags().StringVar(&analyzeCmd.noProxy, "no-proxy", loadEnvInsensitive("no_proxy"), "proxy excluded URLs (relevant only with proxy)")
 
 	return analyzeCommand
 }
@@ -887,6 +887,16 @@ func (a *analyzeCommand) getLabelSelector() string {
 
 func isXMLFile(rule string) bool {
 	return path.Ext(rule) == ".xml"
+}
+
+func loadEnvInsensitive(variableName string) string {
+	lowerValue := os.Getenv(strings.ToLower(variableName))
+	upperValue := os.Getenv(strings.ToUpper(variableName))
+	if lowerValue != "" {
+		return lowerValue
+	} else {
+		return upperValue
+	}
 }
 
 func (a *analyzeCommand) getXMLRulesVolumes(tempRuleDir string) (map[string]string, error) {

--- a/cmd/analyze.go
+++ b/cmd/analyze.go
@@ -61,6 +61,7 @@ type analyzeCommand struct {
 	rules                 []string
 	jaegerEndpoint        string
 	enableDefaultRulesets bool
+	proxy                 string
 
 	// tempDirs list of temporary dirs created, used for cleanup
 	tempDirs []string
@@ -160,6 +161,7 @@ func NewAnalyzeCmd(log logr.Logger) *cobra.Command {
 	analyzeCommand.Flags().BoolVar(&analyzeCmd.overwrite, "overwrite", false, "overwrite output directory")
 	analyzeCommand.Flags().StringVar(&analyzeCmd.jaegerEndpoint, "jaeger-endpoint", "", "jaeger endpoint to collect traces")
 	analyzeCommand.Flags().BoolVar(&analyzeCmd.enableDefaultRulesets, "enable-default-rulesets", true, "run default rulesets with analysis")
+	analyzeCommand.Flags().StringVar(&analyzeCmd.proxy, "proxy", "", "HTTP&HTTPS proxy string URL")
 
 	return analyzeCommand
 }
@@ -457,6 +459,17 @@ func (a *analyzeCommand) getConfigVolumes() (map[string]string, error) {
 				},
 			},
 		},
+	}
+
+	// Set proxy to providers
+	if a.proxy != "" {
+		proxy := provider.Proxy{
+			HTTPProxy: a.proxy,
+			HTTPSProxy: a.proxy,
+		}
+		for i := range provConfig {
+			provConfig[i].Proxy = &proxy
+		}
 	}
 
 	// go provider only supports full analysis mode


### PR DESCRIPTION
Adding `proxy` command line option to specify proxy string as an argument. THe proxy s passed to analyzer providers settings.

Fixes: https://github.com/konveyor/kantra/issues/11