### PR TITLE
:bug: Use RootCommandName for labels lookup

### DIFF
--- a/cmd/analyze.go
+++ b/cmd/analyze.go
@@ -298,7 +298,7 @@ func (a *analyzeCommand) ListLabels(ctx context.Context) error {
 			ctx,
 			WithEnv(runMode, runModeContainer),
 			WithVolumes(volumes),
-			WithEntrypointBin("/usr/local/bin/kantra"),
+			WithEntrypointBin(fmt.Sprintf("/usr/local/bin/%s", Settings.RootCommandName)),
 			WithEntrypointArgs(args...),
 			WithCleanup(a.cleanup),
 		)


### PR DESCRIPTION
Hardcoded `kantra` executable path could be different in other build environments, using Settings.RootCommandName to not depend on the kantra name.

Fixes: https://issues.redhat.com/browse/MTA-1998