### PR TITLE
[backport] :bug: Use RootCommandName for labels lookup (#138)

### DIFF
--- a/cmd/analyze.go
+++ b/cmd/analyze.go
@@ -293,7 +293,7 @@ func (a *analyzeCommand) ListLabels(ctx context.Context) error {
 			ctx,
 			WithEnv(runMode, runModeContainer),
 			WithVolumes(volumes),
-			WithEntrypointBin("/usr/local/bin/kantra"),
+			WithEntrypointBin(fmt.Sprintf("/usr/local/bin/%s", Settings.RootCommandName)),
 			WithEntrypointArgs(args...),
 			WithCleanup(a.cleanup),
 		)


### PR DESCRIPTION
Backport of https://github.com/konveyor/kantra/pull/138

Use RootCommandName for labels lookup

Hardcoded `kantra` executable path could be different in other build environments, using Settings.RootCommandName to not depend on kantra name.

Fixes: https://issues.redhat.com/browse/MTA-1998