### PR TITLE
MTA-2041: send err to analysis command

### DIFF
--- a/cmd/analyze.go
+++ b/cmd/analyze.go
@@ -119,12 +119,10 @@ func NewAnalyzeCmd(log logr.Logger) *cobra.Command {
 			}
 			xmlOutputDir, err := analyzeCmd.ConvertXML(cmd.Context())
 			if err != nil {
-				log.Error(err, "failed to convert xml rules")
 				return err
 			}
 			err = analyzeCmd.RunAnalysis(cmd.Context(), xmlOutputDir)
 			if err != nil {
-				log.Error(err, "failed to run analysis")
 				return err
 			}
 			err = analyzeCmd.CreateJSONOutput()
@@ -749,7 +747,7 @@ func (a *analyzeCommand) RunAnalysis(ctx context.Context, xmlOutputDir string) e
 		WithCleanup(a.cleanup),
 	)
 	if err != nil {
-		return err
+		return fmt.Errorf("error running analysis - see analysis log %v", analysisLogFilePath)
 	}
 
 	a.log.Info("running dependency analysis",
@@ -768,7 +766,7 @@ func (a *analyzeCommand) RunAnalysis(ctx context.Context, xmlOutputDir string) e
 		WithCleanup(a.cleanup),
 	)
 	if err != nil {
-		return err
+		return fmt.Errorf("error running dependency analysis - see dependency log %v", depsLogFilePath)
 	}
 
 	return nil
@@ -1035,7 +1033,7 @@ func (a *analyzeCommand) ConvertXML(ctx context.Context) (string, error) {
 		WithCleanup(a.cleanup),
 	)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("error running windup shim - see shim log %v", shimLogPath)
 	}
 
 	return tempOutputDir, nil

--- a/cmd/shimconvert.go
+++ b/cmd/shimconvert.go
@@ -172,8 +172,7 @@ func (w *windupShimCommand) Run(ctx context.Context) error {
 		WithCleanup(w.cleanup),
 	)
 	if err != nil {
-		w.log.V(1).Error(err, "failed to run convert command")
-		return err
+		return fmt.Errorf("error running windup shim - see shim log %v", shimLogPath)
 	}
 	return nil
 }


### PR DESCRIPTION
Because we send errs to logs: https://github.com/konveyor/kantra/blob/main/cmd/analyze.go#L746 the errors hit during analysis or shim would not bubble up to the analyze command itself: https://github.com/konveyor/kantra/blob/main/cmd/analyze.go#L128 

Closes #148 

