### PR TITLE
Add version

### DIFF
--- a/.github/workflows/multi-arch-image-build.yaml
+++ b/.github/workflows/multi-arch-image-build.yaml
@@ -26,8 +26,9 @@ jobs:
         sed -i "s,FROM quay.io/konveyor/windup-shim\:latest,FROM quay.io/konveyor/windup-shim:${TAG}," Dockerfile
         sed -i "s,FROM quay.io/konveyor/static-report\:latest,FROM quay.io/konveyor/static-report:${TAG}," Dockerfile
         sed -i "s,FROM quay.io/konveyor/analyzer-lsp\:latest,FROM quay.io/konveyor/analyzer-lsp:${TAG}," Dockerfile
+        export BUILD_COMMIT=$(git rev-parse HEAD)
       extra-args: |
-        --build-arg=VERSION=${tag} --build-arg=BUILD_COMMIT=latestsha
+        --build-arg VERSION=${tag} --build-arg BUILD_COMMIT=${BUILD_COMMIT}
     secrets:
       registry_username: ${{ secrets.QUAY_PUBLISH_ROBOT }}
       registry_password: ${{ secrets.QUAY_PUBLISH_TOKEN }}

--- a/.github/workflows/multi-arch-image-build.yaml
+++ b/.github/workflows/multi-arch-image-build.yaml
@@ -26,6 +26,8 @@ jobs:
         sed -i "s,FROM quay.io/konveyor/windup-shim\:latest,FROM quay.io/konveyor/windup-shim:${TAG}," Dockerfile
         sed -i "s,FROM quay.io/konveyor/static-report\:latest,FROM quay.io/konveyor/static-report:${TAG}," Dockerfile
         sed -i "s,FROM quay.io/konveyor/analyzer-lsp\:latest,FROM quay.io/konveyor/analyzer-lsp:${TAG}," Dockerfile
+      extra-args: |
+        --build-arg VERSION=${tag} --build-arg BUILD_COMMIT=$(git rev-parse HEAD)
     secrets:
       registry_username: ${{ secrets.QUAY_PUBLISH_ROBOT }}
       registry_password: ${{ secrets.QUAY_PUBLISH_TOKEN }}

--- a/.github/workflows/multi-arch-image-build.yaml
+++ b/.github/workflows/multi-arch-image-build.yaml
@@ -27,7 +27,7 @@ jobs:
         sed -i "s,FROM quay.io/konveyor/static-report\:latest,FROM quay.io/konveyor/static-report:${TAG}," Dockerfile
         sed -i "s,FROM quay.io/konveyor/analyzer-lsp\:latest,FROM quay.io/konveyor/analyzer-lsp:${TAG}," Dockerfile
       extra-args: |
-        --build-arg VERSION=${tag} --build-arg BUILD_COMMIT=$(git rev-parse HEAD)
+        --build-arg=VERSION=${tag} --build-arg=BUILD_COMMIT=latestsha
     secrets:
       registry_username: ${{ secrets.QUAY_PUBLISH_ROBOT }}
       registry_password: ${{ secrets.QUAY_PUBLISH_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,9 +24,11 @@ COPY main.go main.go
 COPY cmd/ cmd/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o kantra main.go
-RUN CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -a -o darwin-kantra main.go
-RUN CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -a -o windows-kantra main.go
+ARG VERSION
+ARG BUILD_COMMIT
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build --ldflags="-X 'github.com/konveyor-ecosystem/kantra/cmd.Version=$VERSION' -X 'github.com/konveyor-ecosystem/kantra/cmd.BuildCommit=$BUILD_COMMIT'" -a -o kantra main.go
+RUN CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build --ldflags="-X 'github.com/konveyor-ecosystem/kantra/cmd.Version=$VERSION' -X 'github.com/konveyor-ecosystem/kantra/cmd.BuildCommit=$BUILD_COMMIT'" -a -o darwin-kantra main.go
+RUN CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build --ldflags="-X 'github.com/konveyor-ecosystem/kantra/cmd.Version=$VERSION' -X 'github.com/konveyor-ecosystem/kantra/cmd.BuildCommit=$BUILD_COMMIT'" -a -o windows-kantra main.go
 
 FROM quay.io/konveyor/analyzer-lsp:latest
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -24,7 +24,7 @@ var noCleanup bool
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
-	Short:        "A cli tool for analysis and transformation of applications",
+	Short:        "A CLI tool for analysis and transformation of applications",
 	Long:         ``,
 	SilenceUsage: true,
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
@@ -46,6 +46,7 @@ func init() {
 	logger := logrusr.New(logrusLog)
 	rootCmd.AddCommand(NewTransformCommand(logger))
 	rootCmd.AddCommand(NewAnalyzeCmd(logger))
+	rootCmd.AddCommand(NewVersionCommand())
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.

--- a/cmd/settings.go
+++ b/cmd/settings.go
@@ -26,8 +26,6 @@ type Config struct {
 	PodmanBinary    string `env:"PODMAN_BIN" default:"/usr/bin/podman"`
 	RunnerImage     string `env:"RUNNER_IMG" default:"quay.io/konveyor/kantra"`
 	JvmMaxMem       string `env:"JVM_MAX_MEM" default:""`
-	Version         string `env:"VERSION" default:"99.0.0"`
-	BuildCommit     string `env:"BUILD_COMMIT" default:""`
 }
 
 func (c *Config) Load() error {

--- a/cmd/settings.go
+++ b/cmd/settings.go
@@ -26,6 +26,8 @@ type Config struct {
 	PodmanBinary    string `env:"PODMAN_BIN" default:"/usr/bin/podman"`
 	RunnerImage     string `env:"RUNNER_IMG" default:"quay.io/konveyor/kantra"`
 	JvmMaxMem       string `env:"JVM_MAX_MEM" default:""`
+	Version         string `env:"VERSION" default:"99.0.0"`
+	BuildCommit     string `env:"BUILD_COMMIT" default:""`
 }
 
 func (c *Config) Load() error {

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,20 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+func NewVersionCommand() *cobra.Command {
+	versionCmd := &cobra.Command{
+		Use:   "version",
+		Short: "Print the tool version",
+		Long:  "Print this tool version number",
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Printf("Version: %s\n", Settings.Version)
+			fmt.Printf("SHA: %s\n", Settings.BuildCommit)
+		},
+	}
+	return versionCmd
+}

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -8,7 +8,7 @@ import (
 
 var (
 	BuildCommit = ""
-	Version     = "99.0.0"
+	Version     = "v99.0.0"
 )
 
 // Use build flags to set correct Version and BuildCommit

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -6,14 +6,22 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var (
+	BuildCommit = ""
+	Version     = "99.0.0"
+)
+
+// Use build flags to set correct Version and BuildCommit
+// e.g.:
+// --ldflags="-X 'github.com/konveyor-ecosystem/kantra/cmd.Version=1.2.3' -X 'github.com/konveyor-ecosystem/kantra/cmd.BuildCommit=$(git rev-parse HEAD)'"
 func NewVersionCommand() *cobra.Command {
 	versionCmd := &cobra.Command{
 		Use:   "version",
 		Short: "Print the tool version",
 		Long:  "Print this tool version number",
 		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Printf("Version: %s\n", Settings.Version)
-			fmt.Printf("SHA: %s\n", Settings.BuildCommit)
+			fmt.Printf("version: %s\n", Version)
+			fmt.Printf("SHA: %s\n", BuildCommit)
 		},
 	}
 	return versionCmd


### PR DESCRIPTION
Adding tool version to CLI that should return version number and commit hash. Usage: `kantra version`.

The version can be setup when building the kantra, example:
```
$ go build --ldflags="-X 'github.com/konveyor-ecosystem/kantra/cmd.Version=1.1.1' -X 'github.com/konveyor-ecosystem/kantra/cmd.BuildCommit=$(git rev-parse HEAD)'"
$ ./kantra version
version: 1.1.1
SHA: 75daa9736c52e85cad832d1cd2eb95d2d98dad8e

```
The default development version `99.0.0` follows operator and [UI convention](https://github.com/konveyor/tackle2-ui/blob/main/common/src/environment.ts#L63).

Fixes: https://issues.redhat.com/browse/MTA-2201
