### PR TITLE
Fix version variables evaluation in github build

### DIFF
--- a/.github/workflows/multi-arch-image-build.yaml
+++ b/.github/workflows/multi-arch-image-build.yaml
@@ -26,9 +26,8 @@ jobs:
         sed -i "s,FROM quay.io/konveyor/windup-shim\:latest,FROM quay.io/konveyor/windup-shim:${TAG}," Dockerfile
         sed -i "s,FROM quay.io/konveyor/static-report\:latest,FROM quay.io/konveyor/static-report:${TAG}," Dockerfile
         sed -i "s,FROM quay.io/konveyor/analyzer-lsp\:latest,FROM quay.io/konveyor/analyzer-lsp:${TAG}," Dockerfile
-        export BUILD_COMMIT=$(git rev-parse HEAD)
       extra-args: |
-        --build-arg VERSION=${tag} --build-arg BUILD_COMMIT=${BUILD_COMMIT}
+        --build-arg VERSION=${{ github.ref == 'refs/heads/main' && 'latest' || github.ref_name }} --build-arg BUILD_COMMIT=${{ github.sha }}
     secrets:
       registry_username: ${{ secrets.QUAY_PUBLISH_ROBOT }}
       registry_password: ${{ secrets.QUAY_PUBLISH_TOKEN }}


### PR DESCRIPTION
Using github variables to provide version and commit sha variables for build.

Follow-up to https://github.com/konveyor/kantra/pull/154