### PR TITLE
:sparkles: adding override provider settings flag

### DIFF
--- a/pkg/container/container.go
+++ b/pkg/container/container.go
@@ -224,6 +224,7 @@ func (c *container) Run(ctx context.Context, opts ...Option) error {
 			c.containerToolBin, reproducer)
 	}
 	cmd := exec.CommandContext(ctx, c.containerToolBin, args...)
+	fmt.Printf("%v", cmd.String())
 	errBytes := &bytes.Buffer{}
 	cmd.Stdout = nil
 	cmd.Stderr = errBytes


### PR DESCRIPTION
Closes #220 
basically if you use the host DNS name in a provider settings like:

```
[
    {
        "name": "aws",
        "address": "host.containers.internal:10000",
        "initConfig": [
            {
                "location": "shurley-test",
            },
        ],
    },
]
```

notes:

This allows for non-input analysis, which makes sense because location and things must be described in the provider settings. This means we have to turn off the required flag.