### PR TITLE
:bug: Fix labels validation print

### DIFF
--- a/cmd/analyze.go
+++ b/cmd/analyze.go
@@ -495,12 +495,12 @@ func listOptionsFromLabels(sl []string, label string, out io.Writer) {
 	sort.Strings(newSl)
 
 	if label == outputv1.SourceTechnologyLabel {
-		fmt.Println(out, "available source technologies:")
+		fmt.Fprintln(out, "available source technologies:")
 	} else {
-		fmt.Println(out, "available target technologies:")
+		fmt.Fprintln(out, "available target technologies:")
 	}
 	for _, tech := range newSl {
-		fmt.Println(out, tech)
+		fmt.Fprintln(out, tech)
 	}
 }
 

--- a/cmd/settings.go
+++ b/cmd/settings.go
@@ -33,6 +33,10 @@ type Config struct {
 }
 
 func (c *Config) Load() error {
+	err := env.Set(c)
+	if err != nil {
+		return err
+	}
 	if err := c.loadDefaultPodmanBin(); err != nil {
 		return err
 	}
@@ -43,10 +47,6 @@ func (c *Config) Load() error {
 		return err
 	}
 	if err := c.loadProviders(); err != nil {
-		return err
-	}
-	err := env.Set(c)
-	if err != nil {
 		return err
 	}
 	return nil
@@ -85,13 +85,8 @@ func (c *Config) trySetDefaultPodmanBin(file string) (found bool, err error) {
 }
 
 func (c *Config) loadRunnerImg() error {
-	// TODO(maufart): ensure Config struct works/parses it values from ENV and defaults correctly
-	runnerImg, found := os.LookupEnv("RUNNER_IMG");
-	if !found {
-		runnerImg = "quay.io/konveyor/kantra"
-	}
 	// if version tag is given in image
-	img := strings.TrimSuffix(runnerImg, fmt.Sprintf(":%v", Version))
+	img := strings.TrimSuffix(c.RunnerImage, fmt.Sprintf(":%v", Version))
 	updatedImg := fmt.Sprintf("%v:%v", img, Version)
 	err := os.Setenv("RUNNER_IMG", updatedImg)
 	if err != nil {
@@ -102,8 +97,8 @@ func (c *Config) loadRunnerImg() error {
 }
 
 func (c *Config) loadCommandName() error {
-	if RootCommandName != "kantra" {
-		err := os.Setenv("CMD_NAME", RootCommandName)
+	if c.RootCommandName != "kantra" {
+		err := os.Setenv("CMD_NAME", c.RootCommandName)
 		if err != nil {
 			return err
 		}
@@ -113,14 +108,14 @@ func (c *Config) loadCommandName() error {
 
 func (c *Config) loadProviders() error {
 	// if version tag is given in image
-	javaImg := strings.TrimSuffix(JavaProviderImage, fmt.Sprintf(":%v", Version))
+	javaImg := strings.TrimSuffix(c.JavaProviderImage, fmt.Sprintf(":%v", Version))
 	updatedJavaImg := fmt.Sprintf("%v:%v", javaImg, Version)
 	err := os.Setenv("JAVA_PROVIDER_IMG", updatedJavaImg)
 	if err != nil {
 		return err
 	}
 	// if version tag is given in image
-	genericImg := strings.TrimSuffix(GenericProviderImage, fmt.Sprintf(":%v", Version))
+	genericImg := strings.TrimSuffix(c.GenericProviderImage, fmt.Sprintf(":%v", Version))
 	updatedGenericImg := fmt.Sprintf("%v:%v", genericImg, Version)
 	err = os.Setenv("GENERIC_PROVIDER_IMG", updatedGenericImg)
 	if err != nil {

--- a/cmd/settings.go
+++ b/cmd/settings.go
@@ -33,10 +33,6 @@ type Config struct {
 }
 
 func (c *Config) Load() error {
-	err := env.Set(c)
-	if err != nil {
-		return err
-	}
 	if err := c.loadDefaultPodmanBin(); err != nil {
 		return err
 	}
@@ -47,6 +43,10 @@ func (c *Config) Load() error {
 		return err
 	}
 	if err := c.loadProviders(); err != nil {
+		return err
+	}
+	err := env.Set(c)
+	if err != nil {
 		return err
 	}
 	return nil
@@ -85,8 +85,13 @@ func (c *Config) trySetDefaultPodmanBin(file string) (found bool, err error) {
 }
 
 func (c *Config) loadRunnerImg() error {
+	// TODO(maufart): ensure Config struct works/parses it values from ENV and defaults correctly
+	runnerImg, found := os.LookupEnv("RUNNER_IMG");
+	if !found {
+		runnerImg = "quay.io/konveyor/kantra"
+	}
 	// if version tag is given in image
-	img := strings.TrimSuffix(c.RunnerImage, fmt.Sprintf(":%v", Version))
+	img := strings.TrimSuffix(runnerImg, fmt.Sprintf(":%v", Version))
 	updatedImg := fmt.Sprintf("%v:%v", img, Version)
 	err := os.Setenv("RUNNER_IMG", updatedImg)
 	if err != nil {
@@ -97,8 +102,8 @@ func (c *Config) loadRunnerImg() error {
 }
 
 func (c *Config) loadCommandName() error {
-	if c.RootCommandName != "kantra" {
-		err := os.Setenv("CMD_NAME", c.RootCommandName)
+	if RootCommandName != "kantra" {
+		err := os.Setenv("CMD_NAME", RootCommandName)
 		if err != nil {
 			return err
 		}
@@ -108,14 +113,14 @@ func (c *Config) loadCommandName() error {
 
 func (c *Config) loadProviders() error {
 	// if version tag is given in image
-	javaImg := strings.TrimSuffix(c.JavaProviderImage, fmt.Sprintf(":%v", Version))
+	javaImg := strings.TrimSuffix(JavaProviderImage, fmt.Sprintf(":%v", Version))
 	updatedJavaImg := fmt.Sprintf("%v:%v", javaImg, Version)
 	err := os.Setenv("JAVA_PROVIDER_IMG", updatedJavaImg)
 	if err != nil {
 		return err
 	}
 	// if version tag is given in image
-	genericImg := strings.TrimSuffix(c.GenericProviderImage, fmt.Sprintf(":%v", Version))
+	genericImg := strings.TrimSuffix(GenericProviderImage, fmt.Sprintf(":%v", Version))
 	updatedGenericImg := fmt.Sprintf("%v:%v", genericImg, Version)
 	err = os.Setenv("GENERIC_PROVIDER_IMG", updatedGenericImg)
 	if err != nil {

--- a/cmd/settings.go
+++ b/cmd/settings.go
@@ -33,6 +33,10 @@ type Config struct {
 }
 
 func (c *Config) Load() error {
+	err := env.Set(c)
+	if err != nil {
+		return err
+	}
 	if err := c.loadDefaultPodmanBin(); err != nil {
 		return err
 	}
@@ -43,10 +47,6 @@ func (c *Config) Load() error {
 		return err
 	}
 	if err := c.loadProviders(); err != nil {
-		return err
-	}
-	err := env.Set(c)
-	if err != nil {
 		return err
 	}
 	return nil
@@ -85,13 +85,8 @@ func (c *Config) trySetDefaultPodmanBin(file string) (found bool, err error) {
 }
 
 func (c *Config) loadRunnerImg() error {
-	// TODO(maufart): ensure Config struct works/parses it values from ENV and defaults correctly
-	runnerImg, found := os.LookupEnv("RUNNER_IMG");
-	if !found {
-		runnerImg = "quay.io/konveyor/kantra"
-	}
 	// if version tag is given in image
-	img := strings.TrimSuffix(runnerImg, fmt.Sprintf(":%v", Version))
+	img := strings.TrimSuffix(RunnerImage, fmt.Sprintf(":%v", Version))
 	updatedImg := fmt.Sprintf("%v:%v", img, Version)
 	err := os.Setenv("RUNNER_IMG", updatedImg)
 	if err != nil {

--- a/cmd/settings.go
+++ b/cmd/settings.go
@@ -85,8 +85,13 @@ func (c *Config) trySetDefaultPodmanBin(file string) (found bool, err error) {
 }
 
 func (c *Config) loadRunnerImg() error {
+	// TODO(maufart): ensure Config struct works/parses it values from ENV and defaults correctly
+	runnerImg, found := os.LookupEnv("RUNNER_IMG");
+	if !found {
+		runnerImg = "quay.io/konveyor/kantra"
+	}
 	// if version tag is given in image
-	img := strings.TrimSuffix(RunnerImage, fmt.Sprintf(":%v", Version))
+	img := strings.TrimSuffix(runnerImg, fmt.Sprintf(":%v", Version))
 	updatedImg := fmt.Sprintf("%v:%v", img, Version)
 	err := os.Setenv("RUNNER_IMG", updatedImg)
 	if err != nil {

--- a/cmd/settings.go
+++ b/cmd/settings.go
@@ -33,10 +33,6 @@ type Config struct {
 }
 
 func (c *Config) Load() error {
-	err := env.Set(c)
-	if err != nil {
-		return err
-	}
 	if err := c.loadDefaultPodmanBin(); err != nil {
 		return err
 	}
@@ -47,6 +43,10 @@ func (c *Config) Load() error {
 		return err
 	}
 	if err := c.loadProviders(); err != nil {
+		return err
+	}
+	err := env.Set(c)
+	if err != nil {
 		return err
 	}
 	return nil
@@ -85,8 +85,13 @@ func (c *Config) trySetDefaultPodmanBin(file string) (found bool, err error) {
 }
 
 func (c *Config) loadRunnerImg() error {
+	// TODO(maufart): ensure Config struct works/parses it values from ENV and defaults correctly
+	runnerImg, found := os.LookupEnv("RUNNER_IMG");
+	if !found {
+		runnerImg = "quay.io/konveyor/kantra"
+	}
 	// if version tag is given in image
-	img := strings.TrimSuffix(RunnerImage, fmt.Sprintf(":%v", Version))
+	img := strings.TrimSuffix(runnerImg, fmt.Sprintf(":%v", Version))
 	updatedImg := fmt.Sprintf("%v:%v", img, Version)
 	err := os.Setenv("RUNNER_IMG", updatedImg)
 	if err != nil {

--- a/cmd/settings_test.go
+++ b/cmd/settings_test.go
@@ -10,7 +10,7 @@ func TestRunnerImgDefault(t *testing.T) {
 	os.Unsetenv("RUNNER_IMG")	// Ensure empty variable
 	s := &Config{}
 	s.Load();
-	if s.RunnerImage != "quay.io/konveyor/kantra" {
+	if s.RunnerImage != "quay.io/konveyor/kantra:latest" {
 		t.Errorf("Unexpected RUNNER_IMG default: %s", s.RunnerImage)
 	}
 }
@@ -19,7 +19,7 @@ func TestRunnerImgCustom(t *testing.T) {
 	os.Setenv("RUNNER_IMG", "quay.io/some-contributor/my-kantra")
 	s := &Config{}
 	s.Load();
-	if s.RunnerImage != "quay.io/some-contributor/my-kantra" {
+	if s.RunnerImage != "quay.io/some-contributor/my-kantra:latest" {
 		t.Errorf("Unexpected RUNNER_IMG: %s", s.RunnerImage)
 	}
 }

--- a/cmd/settings_test.go
+++ b/cmd/settings_test.go
@@ -1,0 +1,25 @@
+package cmd
+
+import (
+	"os"
+	"testing"
+)
+
+// Test RUNNER_IMG settings
+func TestRunnerImgDefault(t *testing.T) {
+	os.Unsetenv("RUNNER_IMG")	// Ensure empty variable
+	s := &Config{}
+	s.Load();
+	if s.RunnerImage != "quay.io/konveyor/kantra" {
+		t.Errorf("Unexpected RUNNER_IMG default: %s", s.RunnerImage)
+	}
+}
+
+func TestRunnerImgCustom(t *testing.T) {
+	os.Setenv("RUNNER_IMG", "quay.io/some-contributor/my-kantra")
+	s := &Config{}
+	s.Load();
+	if s.RunnerImage != "quay.io/some-contributor/my-kantra" {
+		t.Errorf("Unexpected RUNNER_IMG: %s", s.RunnerImage)
+	}
+}


### PR DESCRIPTION
Fixing fmt.Fprintln to correctly recognize first argument as a writer buffer. Bug was introduced in my PR https://github.com/konveyor/kantra/pull/243

This should fix kantra CI.