### PR TITLE
:sparkles: kantra support .net provider on windows

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,20 +34,24 @@ ARG NAME=kantra
 ARG JAVA_BUNDLE=/jdtls/java-analyzer-bundle/java-analyzer-bundle.core/target/java-analyzer-bundle.core-1.0.0-SNAPSHOT.jar
 ARG JAVA_PROVIDER_IMG=quay.io/konveyor/java-external-provider
 ARG GENERIC_PROVIDER_IMG=quay.io/konveyor/generic-external-provider
+ARG DOTNET_PROVIDER_IMG=quay.io/konveyor/dotnet-external-provider
 
 RUN CGO_ENABLED=0 GOOS=linux go build --ldflags="-X 'github.com/konveyor-ecosystem/kantra/cmd.Version=$VERSION' \
 -X 'github.com/konveyor-ecosystem/kantra/cmd.RunnerImage=$IMAGE' -X 'github.com/konveyor-ecosystem/kantra/cmd.BuildCommit=$BUILD_COMMIT' \
 -X 'github.com/konveyor-ecosystem/kantra/cmd.JavaBundlesLocation=$JAVA_BUNDLE' -X 'github.com/konveyor-ecosystem/kantra/cmd.JavaProviderImage=$JAVA_PROVIDER_IMG' \
+-X 'github.com/konveyor-ecosystem/kantra/cmd.DotnetProviderImage=$DOTNET_PROVIDER_IMG' \
 -X 'github.com/konveyor-ecosystem/kantra/cmd.GenericProviderImage=$GENERIC_PROVIDER_IMG' -X 'github.com/konveyor-ecosystem/kantra/cmd.RootCommandName=$NAME'" -a -o kantra main.go
 
 RUN CGO_ENABLED=0 GOOS=darwin go build --ldflags="-X 'github.com/konveyor-ecosystem/kantra/cmd.Version=$VERSION' \
 -X 'github.com/konveyor-ecosystem/kantra/cmd.RunnerImage=$IMAGE' -X 'github.com/konveyor-ecosystem/kantra/cmd.BuildCommit=$BUILD_COMMIT' \
 -X 'github.com/konveyor-ecosystem/kantra/cmd.JavaBundlesLocation=$JAVA_BUNDLE' -X 'github.com/konveyor-ecosystem/kantra/cmd.JavaProviderImage=$JAVA_PROVIDER_IMG' \
+-X 'github.com/konveyor-ecosystem/kantra/cmd.DotnetProviderImage=$DOTNET_PROVIDER_IMG' \
 -X 'github.com/konveyor-ecosystem/kantra/cmd.GenericProviderImage=$GENERIC_PROVIDER_IMG' -X 'github.com/konveyor-ecosystem/kantra/cmd.RootCommandName=$NAME'" -a -o darwin-kantra main.go
 
 RUN CGO_ENABLED=0 GOOS=windows go build --ldflags="-X 'github.com/konveyor-ecosystem/kantra/cmd.Version=$VERSION' \
 -X 'github.com/konveyor-ecosystem/kantra/cmd.RunnerImage=$IMAGE' -X 'github.com/konveyor-ecosystem/kantra/cmd.BuildCommit=$BUILD_COMMIT' \
 -X 'github.com/konveyor-ecosystem/kantra/cmd.JavaBundlesLocation=$JAVA_BUNDLE' -X 'github.com/konveyor-ecosystem/kantra/cmd.JavaProviderImage=$JAVA_PROVIDER_IMG' \
+-X 'github.com/konveyor-ecosystem/kantra/cmd.DotnetProviderImage=$DOTNET_PROVIDER_IMG' \
 -X 'github.com/konveyor-ecosystem/kantra/cmd.GenericProviderImage=$GENERIC_PROVIDER_IMG' -X 'github.com/konveyor-ecosystem/kantra/cmd.RootCommandName=$NAME'" -a -o windows-kantra main.go
 
 FROM quay.io/konveyor/analyzer-lsp:${VERSION}

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -1,0 +1,68 @@
+ARG VERSION=latest
+
+# FROM quay.io/konveyor/static-report:${VERSION} as static-report
+
+FROM mcr.microsoft.com/windows/servercore:ltsc2022 AS rulesets
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+ENV GIT_VERSION 2.45.2
+ENV GIT_SHA256 7ed2a3ce5bbbf8eea976488de5416894ca3e6a0347cee195a7d768ac146d5290
+
+RUN $url = ('https://github.com/git-for-windows/git/releases/download/v{0}.windows.1/MinGit-{0}-64-bit.zip' -f $env:GIT_VERSION); \
+	Write-Host ('Downloading {0} ...' -f $url); \
+	Invoke-WebRequest -Uri $url -OutFile 'git.zip'; \
+	\
+	Write-Host ('Verifying sha256 ({0}) ...' -f $env:GIT_SHA256); \
+	if ((Get-FileHash git.zip -Algorithm sha256).Hash -ne $env:GIT_SHA256) { throw 'SHA256 mismatch' }; \
+	\
+	Write-Host 'Expanding ...'; \
+	Expand-Archive git.zip -DestinationPath C:\git; \
+	\
+	Write-Host 'Removing ...'; \
+	Remove-Item git.zip -Force; \
+	\
+	Write-Host 'Verifying ("git --version") ...'; \
+	C:\git\cmd\git.exe --version; \
+	\
+	Write-Host 'Complete.';
+
+ARG RULESETS_REF=main
+RUN C:\git\cmd\git.exe clone https://github.com/konveyor/rulesets -b $env:RULESETS_REF C:\rulesets
+
+FROM golang:1.21-windowsservercore-ltsc2022 as builder
+
+WORKDIR /workspace
+# Copy the Go Modules manifests
+COPY go.mod go.mod
+COPY go.sum go.sum
+# cache deps before building and copying source so that we don't need to re-download as much
+# and so that source changes don't invalidate our downloaded layer
+RUN go mod download
+
+# Copy the go source
+COPY main.go main.go
+COPY cmd/ cmd/
+COPY pkg/ pkg/
+
+# Build
+ARG VERSION=latest
+ARG BUILD_COMMIT
+RUN go build -o kantra.exe main.go
+
+FROM quay.io/konveyor/analyzer-lsp:${VERSION}-windowsservercore-ltsc2022
+
+ENV DOTNET_PROVIDER_IMG=quay.io/konveyor/dotnet-external-provider:${VERSION}-ltsc2022
+
+# Set the working directory inside the container
+WORKDIR C:/app
+
+RUN md C:\opt\rulesets\input C:\opt\rulesets\convert C:\opt\openrewrite C:\opt\input\rules\custom C:\opt\output C:\opt\xmlrules C:\opt\shimoutput C:\tmp\source-app C:\tmp\source-app\input
+
+# Copy the executable from the builder stage
+COPY --from=builder /workspace/kantra.exe .
+COPY --from=rulesets /rulesets/default/generated/dotnet8 /opt/rulesets
+#COPY --from=static-report /usr/bin/js-bundle-generator .
+#COPY --from=static-report /usr/local/static-report .
+
+# Command to run the executable
+ENTRYPOINT ["kantra.exe"]

--- a/cmd/settings.go
+++ b/cmd/settings.go
@@ -29,6 +29,7 @@ type Config struct {
 	RunLocal             bool   `env:"RUN_LOCAL"`
 	JavaProviderImage    string `env:"JAVA_PROVIDER_IMG" default:"quay.io/konveyor/java-external-provider:latest"`
 	GenericProviderImage string `env:"GENERIC_PROVIDER_IMG" default:"quay.io/konveyor/generic-external-provider:latest"`
+	DotnetProviderImage  string `env:"DOTNET_PROVIDER_IMG" default:"quay.io/konveyor/dotnet-external-provider:latest"`
 }
 
 func (c *Config) Load() error {

--- a/pkg/container/container.go
+++ b/pkg/container/container.go
@@ -23,6 +23,7 @@ type container struct {
 	Name           string
 	image          string
 	NetworkName    string
+	IPv4           string
 	entrypointBin  string
 	entrypointArgs []string
 	workdir        string
@@ -55,6 +56,12 @@ func WithName(n string) Option {
 func WithNetwork(w string) Option {
 	return func(c *container) {
 		c.NetworkName = w
+	}
+}
+
+func WithIPv4(ip string) Option {
+	return func(c *container) {
+		c.IPv4 = ip
 	}
 }
 
@@ -188,6 +195,10 @@ func (c *container) Run(ctx context.Context, opts ...Option) error {
 	if c.NetworkName != "" {
 		args = append(args, "--network")
 		args = append(args, c.NetworkName)
+	}
+	if c.IPv4 != "" {
+		args = append(args, "--ip")
+		args = append(args, c.IPv4)
 	}
 	if c.entrypointBin != "" {
 		args = append(args, "--entrypoint")


### PR DESCRIPTION
This introduces a provider for analyzing .NET application in the cross-platform and windows-only scenarios described in https://github.com/konveyor/enhancements/pull/179.

Hold for #259 , will rebase after that merges.

Fixes #254 