### PR TITLE
Fix static report url

### DIFF
--- a/cmd/analyze.go
+++ b/cmd/analyze.go
@@ -1561,9 +1561,7 @@ func (a *analyzeCommand) GenerateStaticReport(ctx context.Context) error {
 		return err
 	}
 	uri := uri.File(filepath.Join(a.output, "static-report", "index.html"))
-	cleanedURI := filepath.Clean(string(uri))
-	a.log.Info("Static report created. Access it at this URL:", "URL", cleanedURI)
-
+	a.log.Info("Static report created. Access it at this URL:", "URL", string(uri))
 	return nil
 }
 


### PR DESCRIPTION
Old output: `INFO[0028] Static report created. Access it at this URL:  URL="file:/Users/emilymcmullan/Repos/kantra/output-test/static-report/index.html"`

Fixed output: `INFO[0026] Static report created. Access it at this URL:  URL="file:///Users/emilymcmullan/Repos/kantra/output-test/static-report/index.html"`

Closes #261 