### PR TITLE
:fix :(docs): changed env PODMAN_BIN to CONTAINER_TOOL

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@ Kantra is a CLI that unifies analysis and transformation capabilities of Konveyo
 
 _Podman 4+_ is required to run kantra. By default, it is configured to use the podman executable available on the host. 
 
-Although kantra is primarily tested with podman, _Docker Engine 24+_ or _Docker Desktop 4+_ can be used as an alternative. To use docker, set the environment variable `PODMAN_BIN` pointing to the docker executable's path:
+Although kantra is primarily tested with podman, _Docker Engine 24+_ or _Docker Desktop 4+_ can be used as an alternative. To use docker, set the environment variable `CONTAINER_TOOL` pointing to the docker executable's path:
 
 ```sh
-export PODMAN_BIN=/usr/bin/docker
+export CONTAINER_TOOL=/usr/bin/docker
 ```
 
 ## Installation
@@ -46,7 +46,7 @@ e.g., `kantra_version=v0.4.0`.
 Run:
 
 ```sh
-${PODMAN_BIN:-podman} cp $(${PODMAN_BIN:-podman} create --name kantra-download quay.io/konveyor/kantra:${kantra_version:-latest}):/usr/local/bin/kantra . && ${PODMAN_BIN:-podman} rm kantra-download
+${CONTAINER_TOOL:-podman} cp $(${CONTAINER_TOOL:-podman} create --name kantra-download quay.io/konveyor/kantra:${kantra_version:-latest}):/usr/local/bin/kantra . && ${CONTAINER_TOOL:-podman} rm kantra-download
 ```
 
 #### Mac
@@ -57,7 +57,7 @@ you need to start a podman machine prior to running any podman commands (see [Se
 Once a machine is started, run:
 
 ```sh
-${PODMAN_BIN:-podman} cp $(${PODMAN_BIN:-podman} create --name kantra-download quay.io/konveyor/kantra:${kantra_version:-latest}):/usr/local/bin/darwin-kantra . && ${PODMAN_BIN:-podman} rm kantra-download
+${CONTAINER_TOOL:-podman} cp $(${CONTAINER_TOOL:-podman} create --name kantra-download quay.io/konveyor/kantra:${kantra_version:-latest}):/usr/local/bin/darwin-kantra . && ${CONTAINER_TOOL:-podman} rm kantra-download
 ```
 
 #### Windows
@@ -68,7 +68,7 @@ you need to start a podman machine prior to running any podman commands (see [Se
 Once a machine is started, run:
 
 ```sh
-${PODMAN_BIN:-podman} cp $(${PODMAN_BIN:-podman} create --name kantra-download quay.io/konveyor/kantra:${kantra_version:-latest}):/usr/local/bin/windows-kantra . && ${PODMAN_BIN:-podman} rm kantra-download
+${CONTAINER_TOOL:-podman} cp $(${CONTAINER_TOOL:-podman} create --name kantra-download quay.io/konveyor/kantra:${kantra_version:-latest}):/usr/local/bin/windows-kantra . && ${CONTAINER_TOOL:-podman} rm kantra-download
 ```
 
 > Ensure that you add the executable to the `PATH`.

--- a/cmd/analyze.go
+++ b/cmd/analyze.go
@@ -607,7 +607,7 @@ func (a *analyzeCommand) fetchProviders(ctx context.Context, out io.Writer) erro
 			container.WithLog(a.log.V(1)),
 			container.WithEnv(runMode, runModeContainer),
 			container.WithEntrypointBin(fmt.Sprintf("/usr/local/bin/%s", Settings.RootCommandName)),
-			container.WithContainerToolBin(Settings.PodmanBinary),
+			container.WithContainerToolBin(Settings.ContainerBinary),
 			container.WithEntrypointArgs(args...),
 			container.WithStdout(out),
 			container.WithCleanup(a.cleanup),
@@ -682,7 +682,7 @@ func (a *analyzeCommand) fetchLabels(ctx context.Context, listSources, listTarge
 			container.WithEnv(runMode, runModeContainer),
 			container.WithVolumes(volumes),
 			container.WithEntrypointBin(fmt.Sprintf("/usr/local/bin/%s", Settings.RootCommandName)),
-			container.WithContainerToolBin(Settings.PodmanBinary),
+			container.WithContainerToolBin(Settings.ContainerBinary),
 			container.WithEntrypointArgs(args...),
 			container.WithStdout(out),
 			container.WithCleanup(a.cleanup),
@@ -1116,7 +1116,7 @@ func (a *analyzeCommand) createContainerNetwork() (string, error) {
 		networkName,
 	}
 
-	cmd := exec.Command(Settings.PodmanBinary, args...)
+	cmd := exec.Command(Settings.ContainerBinary, args...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	err := cmd.Run()
@@ -1150,7 +1150,7 @@ func (a *analyzeCommand) createContainerVolume() (string, error) {
 		"o=bind",
 		volName,
 	}
-	cmd := exec.Command(Settings.PodmanBinary, args...)
+	cmd := exec.Command(Settings.ContainerBinary, args...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	err = cmd.Run()
@@ -1202,7 +1202,7 @@ func (a *analyzeCommand) RunProviders(ctx context.Context, networkName string, v
 				container.WithImage(init.image),
 				container.WithLog(a.log.V(1)),
 				container.WithVolumes(volumes),
-				container.WithContainerToolBin(Settings.PodmanBinary),
+				container.WithContainerToolBin(Settings.ContainerBinary),
 				container.WithEntrypointArgs(args...),
 				container.WithDetachedMode(true),
 				container.WithCleanup(a.cleanup),
@@ -1226,7 +1226,7 @@ func (a *analyzeCommand) RunProviders(ctx context.Context, networkName string, v
 				container.WithImage(init.image),
 				container.WithLog(a.log.V(1)),
 				container.WithVolumes(volumes),
-				container.WithContainerToolBin(Settings.PodmanBinary),
+				container.WithContainerToolBin(Settings.ContainerBinary),
 				container.WithEntrypointArgs(args...),
 				container.WithDetachedMode(true),
 				container.WithCleanup(a.cleanup),
@@ -1330,7 +1330,7 @@ func (a *analyzeCommand) RunAnalysisOverrideProviderSettings(ctx context.Context
 		container.WithEntrypointArgs(args...),
 		container.WithEntrypointBin("/usr/local/bin/konveyor-analyzer"),
 		container.WithNetwork("host"),
-		container.WithContainerToolBin(Settings.PodmanBinary),
+		container.WithContainerToolBin(Settings.ContainerBinary),
 		container.WithCleanup(a.cleanup),
 	)
 	if err != nil {
@@ -1459,7 +1459,7 @@ func (a *analyzeCommand) RunAnalysis(ctx context.Context, xmlOutputDir string, v
 		container.WithEntrypointArgs(args...),
 		container.WithEntrypointBin("/usr/local/bin/konveyor-analyzer"),
 		container.WithNetwork(networkName),
-		container.WithContainerToolBin(Settings.PodmanBinary),
+		container.WithContainerToolBin(Settings.ContainerBinary),
 		container.WithCleanup(a.cleanup),
 	)
 	if err != nil {
@@ -1606,7 +1606,7 @@ func (a *analyzeCommand) GenerateStaticReport(ctx context.Context) error {
 		container.WithImage(Settings.RunnerImage),
 		container.WithLog(a.log.V(1)),
 		container.WithEntrypointBin("/bin/sh"),
-		container.WithContainerToolBin(Settings.PodmanBinary),
+		container.WithContainerToolBin(Settings.ContainerBinary),
 		container.WithEntrypointArgs(staticReportCmd...),
 		container.WithVolumes(volumes),
 		container.WithcFlag(true),
@@ -1802,7 +1802,7 @@ func (a *analyzeCommand) ConvertXML(ctx context.Context) (string, error) {
 		container.WithVolumes(volumes),
 		container.WithEntrypointArgs(args...),
 		container.WithEntrypointBin("/usr/local/bin/windup-shim"),
-		container.WithContainerToolBin(Settings.PodmanBinary),
+		container.WithContainerToolBin(Settings.ContainerBinary),
 		container.WithCleanup(a.cleanup),
 	)
 	if err != nil {
@@ -1968,7 +1968,7 @@ func (a *analyzeCommand) RmNetwork(ctx context.Context) error {
 	}
 	cmd := exec.CommandContext(
 		ctx,
-		Settings.PodmanBinary,
+		Settings.ContainerBinary,
 		"network",
 		"rm", a.networkName)
 	a.log.V(1).Info("removing container network",
@@ -1982,7 +1982,7 @@ func (a *analyzeCommand) RmVolumes(ctx context.Context) error {
 	}
 	cmd := exec.CommandContext(
 		ctx,
-		Settings.PodmanBinary,
+		Settings.ContainerBinary,
 		"volume",
 		"rm", a.volumeName)
 	a.log.V(1).Info("removing created volume",
@@ -1997,7 +1997,7 @@ func (a *analyzeCommand) RmProviderContainers(ctx context.Context) error {
 		// it will immediately be removed after it stops
 		cmd := exec.CommandContext(
 			ctx,
-			Settings.PodmanBinary,
+			Settings.ContainerBinary,
 			"stop", con)
 		a.log.V(1).Info("stopping container", "container", con)
 		err := cmd.Run()
@@ -2027,7 +2027,7 @@ func (a *analyzeCommand) getProviderLogs(ctx context.Context) error {
 
 		cmd := exec.CommandContext(
 			ctx,
-			Settings.PodmanBinary,
+			Settings.ContainerBinary,
 			"logs",
 			a.providerContainerNames[i])
 
@@ -2065,7 +2065,7 @@ func (a *analyzeCommand) analyzeDotnetFramework(ctx context.Context) error {
 			Network []string `json:"network"`
 		} `json:"plugins"`
 	}
-	cmd := exec.Command(Settings.PodmanBinary, []string{"system", "info", "--format=json"}...)
+	cmd := exec.Command(Settings.ContainerBinary, []string{"system", "info", "--format=json"}...)
 	out, err := cmd.Output()
 	if err != nil {
 		return err
@@ -2082,7 +2082,7 @@ func (a *analyzeCommand) analyzeDotnetFramework(ctx context.Context) error {
 
 	// Create network
 	networkName := container.RandomName()
-	cmd = exec.Command(Settings.PodmanBinary, []string{"network", "create", "-d", "nat", networkName}...)
+	cmd = exec.Command(Settings.ContainerBinary, []string{"network", "create", "-d", "nat", networkName}...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	err = cmd.Run()
@@ -2125,7 +2125,7 @@ func (a *analyzeCommand) analyzeDotnetFramework(ctx context.Context) error {
 		container.WithVolumes(map[string]string{
 			input: "C:" + filepath.FromSlash(SourceMountPath),
 		}),
-		container.WithContainerToolBin(Settings.PodmanBinary),
+		container.WithContainerToolBin(Settings.ContainerBinary),
 		container.WithEntrypointArgs([]string{fmt.Sprintf("--port=%v", port)}...),
 		container.WithDetachedMode(true),
 		container.WithCleanup(a.cleanup),
@@ -2250,7 +2250,7 @@ func (a *analyzeCommand) analyzeDotnetFramework(ctx context.Context) error {
 		container.WithEntrypointArgs(args...),
 		container.WithEntrypointBin(`C:\app\konveyor-analyzer.exe`),
 		container.WithNetwork(networkName),
-		container.WithContainerToolBin(Settings.PodmanBinary),
+		container.WithContainerToolBin(Settings.ContainerBinary),
 		container.WithCleanup(a.cleanup),
 	)
 	if err != nil {
@@ -2278,7 +2278,7 @@ func (a *analyzeCommand) analyzeDotnetFramework(ctx context.Context) error {
 		ctx,
 		container.WithImage(Settings.RunnerImage),
 		container.WithLog(a.log.V(1)),
-		container.WithContainerToolBin(Settings.PodmanBinary),
+		container.WithContainerToolBin(Settings.ContainerBinary),
 		container.WithEntrypointBin("powershell"),
 		container.WithEntrypointArgs("Copy-Item", `C:\app\static-report\`, "-Recurse", filepath.FromSlash(OutputPath)),
 		container.WithVolumes(volumes),
@@ -2300,7 +2300,7 @@ func (a *analyzeCommand) analyzeDotnetFramework(ctx context.Context) error {
 		ctx,
 		container.WithImage(Settings.RunnerImage),
 		container.WithLog(a.log.V(1)),
-		container.WithContainerToolBin(Settings.PodmanBinary),
+		container.WithContainerToolBin(Settings.ContainerBinary),
 		container.WithEntrypointBin(`C:\app\js-bundle-generator`),
 		container.WithEntrypointArgs(staticReportArgs...),
 		container.WithVolumes(volumes),

--- a/cmd/openrewrite.go
+++ b/cmd/openrewrite.go
@@ -158,7 +158,7 @@ func (o *openRewriteCommand) Run(ctx context.Context) error {
 		container.WithLog(o.log.V(1)),
 		container.WithEntrypointArgs(args...),
 		container.WithEntrypointBin("/usr/bin/openrewrite_entrypoint.sh"),
-		container.WithContainerToolBin(Settings.PodmanBinary),
+		container.WithContainerToolBin(Settings.ContainerBinary),
 		container.WithVolumes(volumes),
 		container.WithWorkDir("/tmp/source-app/input"),
 		container.WithCleanup(o.cleanup),

--- a/cmd/settings.go
+++ b/cmd/settings.go
@@ -24,7 +24,7 @@ const (
 
 type Config struct {
 	RootCommandName      string `env:"CMD_NAME" default:"kantra"`
-	ContainerBinary      string `env:"CONTAINER_TOOL"`
+	ContainerBinary      string `env:"CONTAINER_TOOL" default:"/usr/bin/docker"`
 	PodmanBinary         string `env:"PODMAN_BIN" default:"/usr/bin/podman"`
 	RunnerImage          string `env:"RUNNER_IMG" default:"quay.io/konveyor/kantra"`
 	RunLocal             bool   `env:"RUN_LOCAL"`

--- a/cmd/settings.go
+++ b/cmd/settings.go
@@ -24,7 +24,8 @@ const (
 
 type Config struct {
 	RootCommandName      string `env:"CMD_NAME" default:"kantra"`
-	PodmanBinary         string `env:"CONTAINER_TOOL" default:"/usr/bin/podman"`
+	ContainerBinary      string `env:"CONTAINER_TOOL" default:"/usr/bin/podman"`
+	PodmanBinary         string `env:"PODMAN_BIN" default:"/usr/bin/podman"`
 	RunnerImage          string `env:"RUNNER_IMG" default:"quay.io/konveyor/kantra"`
 	RunLocal             bool   `env:"RUN_LOCAL"`
 	JavaProviderImage    string `env:"JAVA_PROVIDER_IMG" default:"quay.io/konveyor/java-external-provider:latest"`
@@ -54,8 +55,8 @@ func (c *Config) Load() error {
 
 func (c *Config) loadDefaultPodmanBin() error {
 	// Respect existing CONTAINER_TOOL setting.
-	if os.Getenv("CONTAINER_TOOL") != "" {
-		return nil
+	if os.Getenv("CONTAINER_TOOL") != "" || os.Getenv("PODMAN_BIN") != "" {		
+			return nil
 	}
 	// Try to use podman. If it's not found, try to use docker.
 	found, err := c.trySetDefaultPodmanBin("podman")
@@ -77,8 +78,12 @@ func (c *Config) trySetDefaultPodmanBin(file string) (found bool, err error) {
 		return false, err
 	}
 	// If file was found in PATH and it's not already going to be used, specify it in the env var.
-	if path != "" && path != c.PodmanBinary {
+	if path != "" && path != c.ContainerBinary {
 		os.Setenv("CONTAINER_TOOL", path)
+		return true, nil
+	}
+	if path != "" && path != c.PodmanBinary {
+		os.Setenv("PODMAN_BIN", path)
 		return true, nil
 	}
 	return false, nil

--- a/cmd/settings.go
+++ b/cmd/settings.go
@@ -24,8 +24,7 @@ const (
 
 type Config struct {
 	RootCommandName      string `env:"CMD_NAME" default:"kantra"`
-	ContainerBinary      string `env:"CONTAINER_TOOL" default:"/usr/bin/docker"`
-	PodmanBinary         string `env:"PODMAN_BIN" default:"/usr/bin/docker"`
+	ContainerBinary      string `env:"CONTAINER_TOOL" default:"/usr/bin/podman"`
 	RunnerImage          string `env:"RUNNER_IMG" default:"quay.io/konveyor/kantra"`
 	RunLocal             bool   `env:"RUN_LOCAL"`
 	JavaProviderImage    string `env:"JAVA_PROVIDER_IMG" default:"quay.io/konveyor/java-external-provider:latest"`
@@ -55,7 +54,10 @@ func (c *Config) Load() error {
 
 func (c *Config) loadDefaultPodmanBin() error {
 	// Respect existing CONTAINER_TOOL setting.
-	if os.Getenv("CONTAINER_TOOL") != "" || os.Getenv("PODMAN_BIN") != "" {
+	if os.Getenv("CONTAINER_TOOL") != "" {
+		return nil
+	}
+	if os.Getenv("PODMAN_BIN") != "" {
 		return nil
 	}
 	// Try to use podman. If it's not found, try to use docker.
@@ -80,10 +82,6 @@ func (c *Config) trySetDefaultPodmanBin(file string) (found bool, err error) {
 	// If file was found in PATH and it's not already going to be used, specify it in the env var.
 	if path != "" && path != c.ContainerBinary {
 		os.Setenv("CONTAINER_TOOL", path)
-		return true, nil
-	}
-	if path != "" && path != c.PodmanBinary {
-		os.Setenv("PODMAN_BIN", path)
 		return true, nil
 	}
 	return false, nil

--- a/cmd/settings.go
+++ b/cmd/settings.go
@@ -25,7 +25,7 @@ const (
 type Config struct {
 	RootCommandName      string `env:"CMD_NAME" default:"kantra"`
 	ContainerBinary      string `env:"CONTAINER_TOOL" default:"/usr/bin/docker"`
-	PodmanBinary         string `env:"PODMAN_BIN" default:"/usr/bin/podman"`
+	PodmanBinary         string `env:"PODMAN_BIN" default:"/usr/bin/docker"`
 	RunnerImage          string `env:"RUNNER_IMG" default:"quay.io/konveyor/kantra"`
 	RunLocal             bool   `env:"RUN_LOCAL"`
 	JavaProviderImage    string `env:"JAVA_PROVIDER_IMG" default:"quay.io/konveyor/java-external-provider:latest"`

--- a/cmd/settings.go
+++ b/cmd/settings.go
@@ -24,7 +24,7 @@ const (
 
 type Config struct {
 	RootCommandName      string `env:"CMD_NAME" default:"kantra"`
-	PodmanBinary         string `env:"PODMAN_BIN" default:"/usr/bin/podman"`
+	PodmanBinary         string `env:"CONTAINER_TOOL" default:"/usr/bin/podman"`
 	RunnerImage          string `env:"RUNNER_IMG" default:"quay.io/konveyor/kantra"`
 	RunLocal             bool   `env:"RUN_LOCAL"`
 	JavaProviderImage    string `env:"JAVA_PROVIDER_IMG" default:"quay.io/konveyor/java-external-provider:latest"`
@@ -53,8 +53,8 @@ func (c *Config) Load() error {
 }
 
 func (c *Config) loadDefaultPodmanBin() error {
-	// Respect existing PODMAN_BIN setting.
-	if os.Getenv("PODMAN_BIN") != "" {
+	// Respect existing CONTAINER_TOOL setting.
+	if os.Getenv("CONTAINER_TOOL") != "" {
 		return nil
 	}
 	// Try to use podman. If it's not found, try to use docker.
@@ -78,7 +78,7 @@ func (c *Config) trySetDefaultPodmanBin(file string) (found bool, err error) {
 	}
 	// If file was found in PATH and it's not already going to be used, specify it in the env var.
 	if path != "" && path != c.PodmanBinary {
-		os.Setenv("PODMAN_BIN", path)
+		os.Setenv("CONTAINER_TOOL", path)
 		return true, nil
 	}
 	return false, nil

--- a/cmd/settings.go
+++ b/cmd/settings.go
@@ -55,8 +55,8 @@ func (c *Config) Load() error {
 
 func (c *Config) loadDefaultPodmanBin() error {
 	// Respect existing CONTAINER_TOOL setting.
-	if os.Getenv("CONTAINER_TOOL") != "" || os.Getenv("PODMAN_BIN") != "" {		
-			return nil
+	if os.Getenv("CONTAINER_TOOL") != "" || os.Getenv("PODMAN_BIN") != "" {
+		return nil
 	}
 	// Try to use podman. If it's not found, try to use docker.
 	found, err := c.trySetDefaultPodmanBin("podman")

--- a/cmd/settings.go
+++ b/cmd/settings.go
@@ -24,7 +24,7 @@ const (
 
 type Config struct {
 	RootCommandName      string `env:"CMD_NAME" default:"kantra"`
-	ContainerBinary      string `env:"CONTAINER_TOOL" default:"/usr/bin/podman"`
+	ContainerBinary      string `env:"CONTAINER_TOOL"`
 	PodmanBinary         string `env:"PODMAN_BIN" default:"/usr/bin/podman"`
 	RunnerImage          string `env:"RUNNER_IMG" default:"quay.io/konveyor/kantra"`
 	RunLocal             bool   `env:"RUN_LOCAL"`

--- a/cmd/shimconvert.go
+++ b/cmd/shimconvert.go
@@ -172,7 +172,7 @@ func (w *windupShimCommand) Run(ctx context.Context) error {
 		container.WithStderr(shimLog),
 		container.WithEntrypointArgs(args...),
 		container.WithEntrypointBin("/usr/local/bin/windup-shim"),
-		container.WithContainerToolBin(Settings.PodmanBinary),
+		container.WithContainerToolBin(Settings.ContainerBinary),
 		container.WithCleanup(w.cleanup),
 	)
 	if err != nil {

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -36,7 +36,7 @@ func NewTestCommand(log logr.Logger) *cobra.Command {
 			results, err := testing.NewRunner().Run(tests, testing.TestOptions{
 				RunLocal:         Settings.RunLocal,
 				ContainerImage:   Settings.RunnerImage,
-				ContainerToolBin: Settings.PodmanBinary,
+				ContainerToolBin: Settings.ContainerBinary,
 				ProgressPrinter:  testing.PrintProgress,
 				Log:              log.V(3),
 			})

--- a/docs/developer.md
+++ b/docs/developer.md
@@ -1,14 +1,14 @@
 ### Running kantra
 
-Two environment variables control the container runtime and the kantra image: `PODMAN_BIN` and `RUNNER_IMG`:
-- `PODMAN_BIN`: path to your container runtime (podman or docker)
+Two environment variables control the container runtime and the kantra image: `CONTAINER_TOOL` and `RUNNER_IMG`:
+- `CONTAINER_TOOL`: path to your container runtime (podman or docker)
 - `RUNNER_IMG`: the tag of the kantra image to invoke
 
 #### example:
 
 `podman build -f Dockerfile -t kantra:dev`
 
-`RUNNER_IMG=kantra:dev PODMAN_BIN=/usr/local/bin/podman go run main.go analyze --input=<path-to-src-application> --output=./output`
+`RUNNER_IMG=kantra:dev CONTAINER_TOOL=/usr/local/bin/podman go run main.go analyze --input=<path-to-src-application> --output=./output`
 
 #### Helpful flags:
 

--- a/env.local.sample
+++ b/env.local.sample
@@ -5,5 +5,5 @@
 # when running locally, you will need to tweak these values as per your env
 # copy this file to `env.local` and source it in your bash session to use CLI
 
-PODMAN_BIN=
+CONTAINER_TOOL=
 RUNNER_IMG=

--- a/env.local.sample
+++ b/env.local.sample
@@ -5,5 +5,6 @@
 # when running locally, you will need to tweak these values as per your env
 # copy this file to `env.local` and source it in your bash session to use CLI
 
+PODMAN_BIN=
 CONTAINER_TOOL=
 RUNNER_IMG=


### PR DESCRIPTION
This PR changes the environment variable `PODMAN_BIN` to `CONTAINER_TOOL`

as kantra falls back to docker if podman is not present, this variable name makes much more sense.

@dagood Please do have a look and provide any necessary feedback for the same.

Closes #168 