### PR TITLE
:bug: Handle missing containerless-deps

### DIFF
--- a/cmd/analyze-bin.go
+++ b/cmd/analyze-bin.go
@@ -286,6 +286,16 @@ func NewAnalyzeBinCmd(log logr.Logger) *cobra.Command {
 }
 
 func (b *analyzeBinCommand) Validate(ctx context.Context) error {
+	// Validate .kantra in home directory and its content (containerless)
+	requiredDirs := []string{b.homeKantraDir, filepath.Join(b.homeKantraDir, "rulesets"), filepath.Join(b.homeKantraDir, JavaBundlesLocation), filepath.Join(b.homeKantraDir, JDTLSBinLocation)}
+	for _, path := range requiredDirs {
+		if _, err := os.Stat(path); os.IsNotExist(err) {
+			b.log.Error(err, "cannot open required path, ensure that container-less dependencies are installed")
+			return err
+		}
+	}
+
+	// Print-only methods
 	if b.listSources || b.listTargets {
 		return nil
 	}
@@ -431,7 +441,7 @@ func (b *analyzeBinCommand) walkRuleFilesForLabels(label string) ([]string, erro
 	labelsSlice := []string{}
 	path := filepath.Join(b.homeKantraDir, "rulesets")
 	if _, err := os.Stat(path); os.IsNotExist(err) {
-		b.log.Error(err, "cannot find ruleset, ensure containerless-kantra-deps are in place")
+		b.log.Error(err, "cannot open provided path")
 		return nil, err
 	}
 	err := filepath.WalkDir(path, walkRuleSets(path, label, &labelsSlice))

--- a/cmd/analyze-bin.go
+++ b/cmd/analyze-bin.go
@@ -287,7 +287,7 @@ func NewAnalyzeBinCmd(log logr.Logger) *cobra.Command {
 
 func (b *analyzeBinCommand) Validate(ctx context.Context) error {
 	// Validate .kantra in home directory and its content (containerless)
-	requiredDirs := []string{b.homeKantraDir, filepath.Join(b.homeKantraDir, "rulesets"), filepath.Join(b.homeKantraDir, JavaBundlesLocation), filepath.Join(b.homeKantraDir, JDTLSBinLocation)}
+	requiredDirs := []string{b.homeKantraDir, filepath.Join(b.homeKantraDir, RulesetsLocation), filepath.Join(b.homeKantraDir, JavaBundlesLocation), filepath.Join(b.homeKantraDir, JDTLSBinLocation)}
 	for _, path := range requiredDirs {
 		if _, err := os.Stat(path); os.IsNotExist(err) {
 			b.log.Error(err, "cannot open required path, ensure that container-less dependencies are installed")
@@ -439,7 +439,7 @@ func (b *analyzeBinCommand) fetchLabels(ctx context.Context, listSources, listTa
 
 func (b *analyzeBinCommand) walkRuleFilesForLabels(label string) ([]string, error) {
 	labelsSlice := []string{}
-	path := filepath.Join(b.homeKantraDir, "rulesets")
+	path := filepath.Join(b.homeKantraDir, RulesetsLocation)
 	if _, err := os.Stat(path); os.IsNotExist(err) {
 		b.log.Error(err, "cannot open provided path")
 		return nil, err

--- a/cmd/analyze-bin.go
+++ b/cmd/analyze-bin.go
@@ -429,7 +429,11 @@ func (b *analyzeBinCommand) fetchLabels(ctx context.Context, listSources, listTa
 
 func (b *analyzeBinCommand) walkRuleFilesForLabels(label string) ([]string, error) {
 	labelsSlice := []string{}
-	path := filepath.Join(b.homeKantraDir, RulesetsLocation)
+	path := filepath.Join(b.homeKantraDir, "rulesets")
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		b.log.Error(err, "cannot find ruleset, ensure containerless-kantra-deps are in place")
+		return nil, err
+	}
 	err := filepath.WalkDir(path, walkRuleSets(path, label, &labelsSlice))
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Missing container-kantra-deps setup caused kantra analyze-bin command failure (details below). Appears when someone skips README step cloning and moving https://github.com/eemcmullan/containerless-kantra-deps.git to `~/.kantra`

Adding check and error message to fail nicely.

Related to: https://github.com/konveyor/kantra/pull/338

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0xb8c330]

goroutine 1 [running]:
github.com/konveyor-ecosystem/kantra/cmd.(*analyzeBinCommand).walkRuleFilesForLabels.walkRuleSets.func1({0xc0000434c0, 0x1e}, {0x0?, 0x0?}, {0xf049e0, 0xc00026f0b0})
	/home/.../go/src/github.com/konveyor/kantra/cmd/util.go:37 +0x30
path/filepath.WalkDir({0xc0000434c0, 0x1e}, 0xc00020fa08)
	/usr/lib/golang/src/path/filepath/path.go:531 +0x9c
github.com/konveyor-ecosystem/kantra/cmd.(*analyzeBinCommand).walkRuleFilesForLabels(0x7f7c626c24e8?, {0xdb3b53, 0x12})
	/home/.../go/src/github.com/konveyor/kantra/cmd/analyze-bin.go:433 +0xc5
github.com/konveyor-ecosystem/kantra/cmd.(*analyzeBinCommand).fetchLabels(0xc000196b00, {0xe?, 0x1?}, 0x14?, 0x0?, {0xf04740, 0xc00026f080})
	/home/.../go/src/github.com/konveyor/kantra/cmd/analyze-bin.go:418 +0x4d
github.com/konveyor-ecosystem/kantra/cmd.(*analyzeBinCommand).Validate(0xc000196b00, {0xf0d608, 0xc0000bb3b0})
	/home/.../go/src/github.com/konveyor/kantra/cmd/analyze-bin.go:315 +0x22f
github.com/konveyor-ecosystem/kantra/cmd.NewAnalyzeBinCmd.func1(0xc000284f08, {0xc00029e060?, 0x4?, 0xda66ad?})
	/home/.../go/src/github.com/konveyor/kantra/cmd/analyze-bin.go:95 +0x192
github.com/spf13/cobra.(*Command).execute(0xc000284f08, {0xc00029e000, 0x6, 0x6})
	/home/.../go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:970 +0xa44
github.com/spf13/cobra.(*Command).ExecuteC(0x152ec00)
	/home/.../go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:1117 +0x3ff
github.com/spf13/cobra.(*Command).Execute(...)
	/home/.../go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:1041
github.com/spf13/cobra.(*Command).ExecuteContext(...)
	/home/.../go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:1034
github.com/konveyor-ecosystem/kantra/cmd.Execute()
	/home/.../go/src/github.com/konveyor/kantra/cmd/root.go:67 +0x10c
main.main()
	/home/.../go/src/github.com/konveyor/kantra/main.go:8 +0xf

```