### PR TITLE
[BUG-FIX]:  Fix issue with 'cp' command not compatible on Windows for containerless analyze

### DIFF
--- a/cmd/analyze-bin.go
+++ b/cmd/analyze-bin.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"log"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"runtime"
 	"sort"
@@ -559,16 +558,14 @@ func (a *analyzeCommand) buildStaticReportFile(ctx context.Context, staticReport
 }
 
 func (a *analyzeCommand) buildStaticReportOutput(ctx context.Context, log *os.File) error {
-	outputFileDestPath := filepath.Join(a.kantraDir, "static-report")
+	outputFolderSrcPath := filepath.Join(a.kantraDir, "static-report")
+	outputFolderDestPath := filepath.Join(a.output, "static-report")
 
-	// move build dir to user output dir
-	cmd := exec.Command("cp", "-r", outputFileDestPath, a.output)
-	cmd.Stdout = log
-	err := cmd.Run()
+	//copy static report files to output folder
+	err := copyFolderContents(outputFolderSrcPath, outputFolderDestPath)
 	if err != nil {
 		return err
 	}
-
 	return nil
 }
 

--- a/cmd/analyze.go
+++ b/cmd/analyze.go
@@ -1074,6 +1074,42 @@ func (a *analyzeCommand) handleDir(p string, tempDir string, basePath string) er
 	return err
 }
 
+func copyFolderContents(src string, dst string) error {
+	err := os.MkdirAll(dst, os.ModePerm)
+	if err != nil {
+		return err
+	}
+	source, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer source.Close()
+
+	contents, err := source.Readdir(-1)
+	if err != nil {
+		return err
+	}
+
+	for _, item := range contents {
+		sourcePath := filepath.Join(src, item.Name())
+		destinationPath := filepath.Join(dst, item.Name())
+
+		if item.IsDir() {
+			// Recursively copy subdirectories
+			if err := copyFolderContents(sourcePath, destinationPath); err != nil {
+				return err
+			}
+		} else {
+			// Copy file
+			if err := copyFileContents(sourcePath, destinationPath); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
 func copyFileContents(src string, dst string) (err error) {
 	source, err := os.Open(src)
 	if err != nil {


### PR DESCRIPTION
This PR introduces a fix for containerless approach
1) A platform-agnostic approach for copying folder contents from the Kantra home path to the specified output during analysis. It enhances the copy functionality to ensure compatibility across all platforms.
2) Tested on: Windows, Linux
