### PR TITLE
:bug: Populate errors for containerless validation flags

### DIFF
--- a/cmd/analyze-bin.go
+++ b/cmd/analyze-bin.go
@@ -232,14 +232,14 @@ func (a *analyzeCommand) ValidateContainerless(ctx context.Context) error {
 		cmd := exec.Command("python", "--version")
 		output, err := cmd.Output()
 		if err != nil {
-			return err
+			return fmt.Errorf("%w cannot execute required command python; ensure python is installed", err)
 		}
 		version := strings.TrimSpace(string(output))
 		pythonVersionStr := strings.Split(version, " ")
 		versionStr := strings.Split(pythonVersionStr[1], ".")
 		versionInt, err := strconv.Atoi(versionStr[0])
 		if err != nil {
-			return err
+			return fmt.Errorf("%w cannot parse python version", err)
 		}
 		if versionInt < 3 {
 			return fmt.Errorf("%w cannot find requirement python3; ensure python3 is installed", err)
@@ -259,7 +259,7 @@ func (a *analyzeCommand) ValidateContainerless(ctx context.Context) error {
 	cmd := exec.Command("java", "-version")
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		return err
+		return fmt.Errorf("%w cannot execute required command java; ensure java is installed", err)
 	}
 	if strings.Contains(string(output), "openjdk") {
 		re := regexp.MustCompile(`openjdk version "(.*?)"`)
@@ -267,7 +267,7 @@ func (a *analyzeCommand) ValidateContainerless(ctx context.Context) error {
 		jdkVersionStr := strings.Split(match[1], ".")
 		jdkVersionInt, err := strconv.Atoi(jdkVersionStr[0])
 		if err != nil {
-			return err
+			return fmt.Errorf("%w cannot parse java version", err)
 		}
 		if jdkVersionInt < 17 {
 			return fmt.Errorf("cannot find requirement openjdk17+; ensure openjdk17+ is installed")


### PR DESCRIPTION
Few missing requirements like Python was producing not helpful messages (like `Failed to validate flags error 90009`) on Windows.

Adding relevant error messages based on debugging containerless kantra on Windows with Igor.

Fixes: https://issues.redhat.com/browse/MTA-4319