### PR TITLE
Container-less Kantra: Update dep label selector to explicitly not scan open-source libraries when analyze-known-libraries is not set

### DIFF
--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -23,17 +23,6 @@ jobs:
     if: github.event_name == 'push' || github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
-      - name: Setup Homebrew
-        uses: Homebrew/actions/setup-homebrew@master
-
-      - name: Upgrade podman 
-        run: |
-          sudo apt-get install -y ansible
-#          export DEB=$(curl -s https://passt.top/builds/latest/x86_64/ | grep deb | awk -F '"' '{ print $4}')
-#          sudo ansible -m apt -a deb=https://passt.top/builds/latest/x86_64/${DEB} localhost
-          sudo apt-get remove podman crun
-          brew install crun podman
-
       - name: Extract pull request number from inputs or PR description
         run: |
           echo "${{ github.event.pull_request.body }}"
@@ -105,17 +94,6 @@ jobs:
     if: github.event_name != 'push' && github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     steps:
-      - name: Setup Homebrew
-        uses: Homebrew/actions/setup-homebrew@master
-
-      - name: Upgrade podman 
-        run: |
-          sudo apt-get install -y ansible
-          export DEB=$(curl -s https://passt.top/builds/latest/x86_64/ | grep deb | awk -F '"' '{ print $4}')
-          sudo ansible -m apt -a deb=https://passt.top/builds/latest/x86_64/${DEB} localhost
-          sudo apt-get remove podman crun
-          brew install crun podman
-
       - uses: actions/checkout@v3
         with:
           ref: ${{ inputs.tag == 'latest' && 'main' || inputs.tag }}

--- a/cmd/analyze-bin.go
+++ b/cmd/analyze-bin.go
@@ -100,8 +100,8 @@ func (a *analyzeCommand) RunAnalysisContainerless(ctx context.Context) error {
 	}
 
 	var dependencyLabelSelector *labels.LabelSelector[*konveyor.Dep]
-	depLabel := fmt.Sprintf("%v=open-source", provider.DepSourceLabel)
-	if a.analyzeKnownLibraries {
+	depLabel := fmt.Sprintf("!%v=open-source", provider.DepSourceLabel)
+	if !a.analyzeKnownLibraries {
 		dependencyLabelSelector, err = labels.NewLabelSelector[*konveyor.Dep](depLabel, nil)
 		if err != nil {
 			errLog.Error(err, "failed to create label selector from expression", "selector", depLabel)


### PR DESCRIPTION
This PR is to fix the mentions/ incidents from .m2 folder even though the --analyze-known-libraries flag is not set for java binary analysis. 