### PR TITLE
:bug: Close analysis.log before generate static-report

### DIFF
--- a/cmd/analyze-bin.go
+++ b/cmd/analyze-bin.go
@@ -53,7 +53,6 @@ func (a *analyzeCommand) RunAnalysisContainerless(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed creating provider log file at %s", analysisLogFilePath)
 	}
-	defer analysisLog.Close()
 
 	// try to convert any xml rules
 	xmlTempDir, err := a.ConvertXMLContainerless()
@@ -215,6 +214,9 @@ func (a *analyzeCommand) RunAnalysisContainerless(ctx context.Context) error {
 		a.log.Error(err, "failed to create json output file")
 		return err
 	}
+
+	// Ensure analysis log is closed before creating static-report (needed for bulk on Windows)
+	analysisLog.Close()
 
 	err = a.GenerateStaticReportContainerless(ctx)
 	if err != nil {

--- a/cmd/analyze-bin.go
+++ b/cmd/analyze-bin.go
@@ -53,6 +53,7 @@ func (a *analyzeCommand) RunAnalysisContainerless(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed creating provider log file at %s", analysisLogFilePath)
 	}
+	defer analysisLog.Close()
 
 	// try to convert any xml rules
 	xmlTempDir, err := a.ConvertXMLContainerless()


### PR DESCRIPTION
Related to containerless --bulk analysis on Windows. Remove of analysis.log silently failed since it was still opened (which appears on Windows only), moving the file `Close()` from `defer` to just before generating static-report.

If some error occured before reaching the Close, the file should be closed by golang garbage collector.

Fixes: https://issues.redhat.com/browse/MTA-4307