### PR TITLE
[backport] :bug: Close analysis.log before generate static-report (#415)

### DIFF
--- a/cmd/analyze-bin.go
+++ b/cmd/analyze-bin.go
@@ -216,6 +216,9 @@ func (a *analyzeCommand) RunAnalysisContainerless(ctx context.Context) error {
 		return err
 	}
 
+	// Ensure analysis log is closed before creating static-report (needed for bulk on Windows)
+	analysisLog.Close()
+
 	err = a.GenerateStaticReportContainerless(ctx)
 	if err != nil {
 		a.log.Error(err, "failed to generate static report")


### PR DESCRIPTION
* Close analysis.log before generate static-report

Related to containerless --bulk analysis on Windows. Remove of analysis.log silently failed since it was still opened (which appears on Windows), moving the file `Close()` from `defer` just before generating static-report.

Fixes: https://issues.redhat.com/browse/MTA-4307



* Re-add Close in defer



---------