### PR TITLE
:sparkles: Return error if not all tests match, add insights to testing

### DIFF
--- a/cmd/test.go
+++ b/cmd/test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/go-logr/logr"
@@ -33,7 +34,7 @@ func NewTestCommand(log logr.Logger) *cobra.Command {
 				log.Info("no tests found")
 				return nil
 			}
-			results, err := testing.NewRunner().Run(tests, testing.TestOptions{
+			results, allPass, err := testing.NewRunner().Run(tests, testing.TestOptions{
 				RunLocal:         Settings.RunLocal,
 				ContainerImage:   Settings.RunnerImage,
 				ContainerToolBin: Settings.ContainerBinary,
@@ -44,6 +45,9 @@ func NewTestCommand(log logr.Logger) *cobra.Command {
 			if err != nil {
 				log.Error(err, "failed running tests")
 				return err
+			}
+			if !allPass {
+				return fmt.Errorf("one or more tests failed")
 			}
 			return nil
 		},

--- a/pkg/testing/runner.go
+++ b/pkg/testing/runner.go
@@ -24,7 +24,7 @@ import (
 // Runner given a list of TestsFile and a TestOptions
 // runs the tests, computes and returns results
 type Runner interface {
-	Run([]TestsFile, TestOptions) ([]Result, error)
+	Run([]TestsFile, TestOptions) ([]Result, bool, error)
 }
 
 type TestOptions struct {
@@ -130,7 +130,7 @@ func NewRunner() Runner {
 // groups tests within a file by analysisParams
 type defaultRunner struct{}
 
-func (r defaultRunner) Run(testFiles []TestsFile, opts TestOptions) ([]Result, error) {
+func (r defaultRunner) Run(testFiles []TestsFile, opts TestOptions) ([]Result, bool, error) {
 	if opts.Log.GetSink() == nil {
 		opts.Log = logr.Discard()
 	}
@@ -284,12 +284,12 @@ func (r defaultRunner) Run(testFiles []TestsFile, opts TestOptions) ([]Result, e
 	})
 
 	if anyErrored {
-		return allResults, fmt.Errorf("failed to execute one or more tests")
+		return allResults, false, fmt.Errorf("failed to execute one or more tests")
 	}
 	if anyFailed {
-		return allResults, fmt.Errorf("one or more tests failed")
+		return allResults, false, fmt.Errorf("one or more tests failed")
 	}
-	return allResults, nil
+	return allResults, true, nil
 }
 
 func runLocal(logFile io.Writer, dir string, analysisParams AnalysisParams) (string, error) {


### PR DESCRIPTION
- Return error if not all tests pass so that we can fail the CI job
- Add the ability to match on insights