### PR TITLE
[Windows-Only] Container less: Remove condition for windows cleanup additional folders logic

### DIFF
--- a/cmd/cleanup.go
+++ b/cmd/cleanup.go
@@ -94,12 +94,7 @@ func (c *AnalyzeCommandContext) RmProviderContainers(ctx context.Context) error 
 	return nil
 }
 
-func (a *analyzeCommand) cleanlsDirs() error {
-	// TODO clean this up for windows
-	// currently a perm issue with deleting these dirs
-	if runtime.GOOS == "windows" {
-		return nil
-	}
+func (a *analyzeCommand) cleanlsDirs() error {	
 	a.log.V(7).Info("removing language server dirs")
 	// this assumes dirs created in wd
 	lsDirs := []string{

--- a/cmd/cleanup.go
+++ b/cmd/cleanup.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"os"
 	"os/exec"
-	"runtime"
 )
 
 func (a *analyzeCommand) CleanAnalysisResources(ctx context.Context) error {
@@ -94,7 +93,7 @@ func (c *AnalyzeCommandContext) RmProviderContainers(ctx context.Context) error 
 	return nil
 }
 
-func (a *analyzeCommand) cleanlsDirs() error {	
+func (a *analyzeCommand) cleanlsDirs() error {
 	a.log.V(7).Info("removing language server dirs")
 	// this assumes dirs created in wd
 	lsDirs := []string{


### PR DESCRIPTION
Summary of changes:
- Removed the condition for windows cleanup additional folders logic
- This is a fix for:  https://github.com/konveyor/kantra/issues/363
