### PR TITLE
fix remove dependencies.yaml file error in bulk mode 

### DIFF
--- a/cmd/analyze.go
+++ b/cmd/analyze.go
@@ -1323,8 +1323,16 @@ func (a *analyzeCommand) moveResults() error {
 	if err != nil {
 		return err
 	}
-	err = CopyFileContents(depsPath, fmt.Sprintf("%s.%s", depsPath, a.inputShortName()))
-	if err == nil { // dependencies file presence is optional
+	// dependencies.yaml is optional
+	_, noDepFileErr := os.Stat(depsPath)
+	if errors.Is(noDepFileErr, os.ErrNotExist) && a.mode == string(provider.FullAnalysisMode) {
+		return noDepFileErr
+	}
+	if noDepFileErr == nil {
+		err = CopyFileContents(depsPath, fmt.Sprintf("%s.%s", depsPath, a.inputShortName()))
+		if err != nil {
+			return err
+		}
 		err = os.Remove(depsPath)
 		if err != nil {
 			return err


### PR DESCRIPTION
When run `kantra analyze`  to analyze an java app with --bulk and --mode=source-only param, the "dependencies.yaml" won't be genenerate, so when `GenerateStaticReportContainerless` in bulk mode, the [moveResult](https://github.com/konveyor/kantra/blob/main/cmd/analyze-bin.go#L688-L690) will occur an exception due to it try to delete a unexist file, see [here](https://github.com/konveyor/kantra/blob/main/cmd/analyze.go#L1326-L1332). The `kantra analyze` command didn't print an error about it because the error is not handled when call [moveResult](https://github.com/konveyor/kantra/blob/main/cmd/analyze-bin.go#L688-L690).

It should be fixed