### PR TITLE
add rule progress logs

### DIFF
--- a/cmd/analyze-bin.go
+++ b/cmd/analyze-bin.go
@@ -35,6 +35,27 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
+type ConsoleHook struct {
+	Level logrus.Level
+	Log   logr.Logger
+}
+
+func (hook *ConsoleHook) Fire(entry *logrus.Entry) error {
+	_, err := entry.String()
+	if err != nil {
+		return nil // Ignore the error
+	}
+
+	if entry.Data["logger"] == "process-rule" {
+		hook.Log.Info("processing rule", "ruleID", entry.Data["ruleID"])
+	}
+	return nil
+}
+
+func (hook *ConsoleHook) Levels() []logrus.Level {
+	return logrus.AllLevels
+}
+
 func (a *analyzeCommand) RunAnalysisContainerless(ctx context.Context) error {
 	err := a.ValidateContainerless(ctx)
 	if err != nil {
@@ -79,6 +100,11 @@ func (a *analyzeCommand) RunAnalysisContainerless(ctx context.Context) error {
 	logrusAnalyzerLog.SetOutput(analysisLog)
 	logrusAnalyzerLog.SetFormatter(&logrus.TextFormatter{})
 	logrusAnalyzerLog.SetLevel(logrus.Level(logLevel))
+
+	// add log hook, print the rule processing to the console
+	consoleHook := &ConsoleHook{Level: logrus.InfoLevel, Log: a.log}
+	logrusAnalyzerLog.AddHook(consoleHook)
+
 	analyzeLog := logrusr.New(logrusAnalyzerLog)
 
 	// log kantra errs to stderr


### PR DESCRIPTION
As #444 mentioned, currently, when running kantra CLI command, if multiple rule are processing, then the log will print to the analysis.log, the log in console will not update for a long time. it's better to show to log processing in the console so user can know how many rules has been processed.

Here, use a console hook to print the logs in console

Related PR in analyzer-lsp: https://github.com/konveyor/analyzer-lsp/pull/796

The log looks like:
![image](https://github.com/user-attachments/assets/45b1b0b3-bcbe-4390-ba10-7d9ffa7daedc)
