### PR TITLE
Cleanup containers after each run

### DIFF
--- a/pkg/testing/runner.go
+++ b/pkg/testing/runner.go
@@ -343,6 +343,7 @@ func runInContainer(consoleLogger logr.Logger, image string, containerBin string
 		container.WithImage(image),
 		container.WithLog(consoleLogger),
 		container.WithEntrypointBin("konveyor-analyzer"),
+		container.WithCleanup(true),
 		container.WithContainerToolBin(containerBin),
 		container.WithEntrypointArgs(args...),
 		container.WithVolumes(volumes),


### PR DESCRIPTION
See ruleset tests stopping sometimes: https://github.com/konveyor/rulesets/actions/runs/14169025279/job/39693238298?pr=262

A potential cause is resources not being properly cleaned up. This will remove dangling containers.