### PR TITLE
:bug: Fix local test run

### DIFF
--- a/pkg/testing/runner.go
+++ b/pkg/testing/runner.go
@@ -190,6 +190,9 @@ func (r defaultRunner) Run(testFiles []TestsFile, opts TestOptions) ([]Result, e
 				// Run with kantra on local mode
 				// For the moment lets assume that all the data for a given test is in the same dataPath
 				dataPath := testsFile.Providers[0].DataPath
+				if dataPath == "" {
+					err = fmt.Errorf("the dataPath field cannot be empty")
+				}
 				dataPath = filepath.Join(filepath.Dir(testsFile.Path), filepath.Clean(dataPath))
 				if reproducerCmd, err = runLocal(logFile, tempDir, analysisParams, dataPath); err != nil {
 					results = append(results, Result{


### PR DESCRIPTION
The test runner wasn't working properly with runLocal because it required the presence of the `konveyor-analyzer` bin. The easiest way to run each test locally is by calling `kantra analyze` itself. That allows us to reuse all that code.

Will hopefully fix https://github.com/konveyor/rulesets/pull/262