### PR TITLE
Update Java prov for cached dep errors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -125,7 +125,7 @@ require (
 	github.com/fabianvf/windup-rulesets-yaml v0.5.3
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/konveyor/analyzer-lsp v0.7.0-alpha.2.0.20250430114706-8854fd4af817
-	github.com/konveyor/analyzer-lsp/external-providers/java-external-provider v0.0.0-20250616135656-f22905672c1a
+	github.com/konveyor/analyzer-lsp/external-providers/java-external-provider v0.0.0-20250625194402-05dca9b4ac43
 	github.com/shopspring/decimal v1.4.0 // indirect
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/pflag v1.0.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -135,8 +135,8 @@ github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/konveyor/analyzer-lsp v0.7.0-alpha.2.0.20250430114706-8854fd4af817 h1:djFH11gT7o/r396ZUm8vE7PHg/1ZiUI7hqMraEUNzOI=
 github.com/konveyor/analyzer-lsp v0.7.0-alpha.2.0.20250430114706-8854fd4af817/go.mod h1:/7nwwqN27iODJy/PBai9W16KH91LrPGx1nwu21+rCOg=
-github.com/konveyor/analyzer-lsp/external-providers/java-external-provider v0.0.0-20250616135656-f22905672c1a h1:rnTnlOcLbooN5musMlZKswRCv2xJRxwSf1PBBuic4K8=
-github.com/konveyor/analyzer-lsp/external-providers/java-external-provider v0.0.0-20250616135656-f22905672c1a/go.mod h1:kHyF5KM41QiwGQG3Ea58qbqu4MiK5hIGZks2Per0qT8=
+github.com/konveyor/analyzer-lsp/external-providers/java-external-provider v0.0.0-20250625194402-05dca9b4ac43 h1:nDEt0L6tGKoTtKQQ0EPug8x3B8S8+8D0jxlM1ka4iRE=
+github.com/konveyor/analyzer-lsp/external-providers/java-external-provider v0.0.0-20250625194402-05dca9b4ac43/go.mod h1:kHyF5KM41QiwGQG3Ea58qbqu4MiK5hIGZks2Per0qT8=
 github.com/konveyor/asset-generation v0.0.0-20250421144442-ed6bee8e1cd2 h1:JfCuD1cJW3O4tXkdtF3TMrd4emTfQmfDHe8grAQl/w8=
 github.com/konveyor/asset-generation v0.0.0-20250421144442-ed6bee8e1cd2/go.mod h1:p1yAhn+hWvgRnC7+dhvimT324TV5YW2FLR7bf+S1GH4=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated an external Java provider dependency to a newer version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->