### PR TITLE
(asset generation): add "--list-apps" flag to "discover"

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,9 +292,10 @@ All flags for Cloud Foundry discovery:
 Flags:
       --app-name string          Name of the Cloud Foundry application to discover.
       --cf-config string         Path to the Cloud Foundry CLI configuration file (default: ~/.cf/config). (default "~/.cf/config")
-      --conceal-sensitive-data   Extract sensitive information in the discover manifest into a separate file.
+      --conceal-sensitive-data   Extract sensitive information in the discover manifest into a separate file (default: false).
   -h, --help                     help for cloud-foundry
       --input string             input path of the manifest file or folder to analyze
+      --list-apps                List applications available for each space.
       --output-dir string        Directory where output manifests will be saved (default: standard output). If the directory does not exist, it will be created automatically.
       --platformType string      Platform type for discovery. Allowed value is: "cloud-foundry" (default). (default "cloud-foundry")
       --skip-ssl-validation      Skip SSL certificate validation for API connections (default: false).
@@ -323,6 +324,13 @@ To run discovery on Cloud Foundry manifest files in an input directory and save 
 ```sh
 kantra discover cloud-foundry --input=<path-to/manifest-dir> --output-dir=<path-to/output-dir>
 ```
+To run discovery on Cloud Foundry manifest files in an input directory and list
+the available applications:
+
+```sh
+kantra discover cloud-foundry --input=<path-to/manifest-dir> --list-apps
+```
+
 To run discovery on Cloud Foundry manifest files in an input directory and 
 separate sensitive data (credentials, secrets) into a dedicated file:
 
@@ -334,6 +342,13 @@ To run live discovery from Cloud Foundry platform on a subset of spaces:
 
 ```sh
 kantra discover cloud-foundry --use-live-connection --spaces=<space1,space2>
+```
+
+To run live discovery from Cloud Foundry platform on a subset of spaces list
+the available applications:
+
+```sh
+kantra discover cloud-foundry --use-live-connection --spaces=<space1,space2> --list-apps
 ```
 
 To run live discovery from Cloud Foundry platform on a subset of spaces and save

--- a/cmd/asset_generation/discover/cloud_foundry/cmd_test.go
+++ b/cmd/asset_generation/discover/cloud_foundry/cmd_test.go
@@ -3,11 +3,15 @@ package cloud_foundry
 import (
 	"bufio"
 	"bytes"
+	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/go-logr/logr"
+	cfProvider "github.com/konveyor/asset-generation/pkg/providers/discoverers/cloud_foundry"
+	pTypes "github.com/konveyor/asset-generation/pkg/providers/types/provider"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/spf13/cobra"
@@ -127,292 +131,413 @@ var _ = Describe("Discover command", func() {
 		os.RemoveAll(tempDir)
 	})
 
-	Context("when input flag is provided", func() {
-		It("should discover manifest and print to stdout by default", func() {
-			_, cmd = NewDiscoverCloudFoundryCommand(log)
-			cmd.SetOut(&out)
-			cmd.SetErr(&err)
-			cmd.SetArgs([]string{"--input", manifestPath})
+	Context("flags validation", func() {
+		Context("when flag combinations are invalid", func() {
+			It("should reject mutually exclusive flags: use-live-connection and input", func() {
+				_, cmd = NewDiscoverCloudFoundryCommand(log)
+				cmd.SetOut(&out)
+				cmd.SetErr(&err)
+				cmd.SetArgs([]string{"--use-live-connection", "--spaces", "test-space",
+					"--cf-config", "../../../../test-data/asset_generation/discover", "--input", manifestPath})
 
-			executeErr := cmd.Execute()
+				executeErr := cmd.Execute()
 
-			Expect(executeErr).To(Succeed())
-			Expect(out.String()).To(ContainSubstring("test-app"))
-			Expect(err.String()).To(BeEmpty())
+				Expect(executeErr).To(HaveOccurred())
+				Expect(executeErr.Error()).To(ContainSubstring("[input use-live-connection] were all set"))
+			})
 		})
+		Context("when required flags are missing", func() {
+			It("should return error when input flag is not provided", func() {
+				_, cmd = NewDiscoverCloudFoundryCommand(log)
+				cmd.SetOut(&out)
+				cmd.SetErr(&err)
+				cmd.SetArgs([]string{})
 
-		It("should produce correct YAML output format", func() {
-			_, cmd = NewDiscoverCloudFoundryCommand(log)
-			cmd.SetOut(&out)
-			cmd.SetErr(&err)
-			cmd.SetArgs([]string{"--input", manifestPath})
+				executeErr := cmd.Execute()
 
-			executeErr := cmd.Execute()
+				Expect(executeErr).To(HaveOccurred())
+				Expect(err.String()).To(ContainSubstring("Error: input flag is required"))
+			})
 
-			Expect(executeErr).To(Succeed())
-			expectedOutput := getExpectedYAMLOutput()
-			Expect(strings.TrimSpace(out.String())).To(Equal(strings.TrimSpace("--- Content Section ---\n" + expectedOutput)))
+			It("should return error when use-live-connection is true but no spaces provided", func() {
+				_, cmd = NewDiscoverCloudFoundryCommand(log)
+				cmd.SetOut(&out)
+				cmd.SetErr(&err)
+				cmd.SetArgs([]string{"--use-live-connection"})
+
+				executeErr := cmd.Execute()
+
+				Expect(executeErr).To(HaveOccurred())
+				Expect(executeErr.Error()).To(ContainSubstring("at least one space is required"))
+			})
+		})
+		Context("when output-dir flag is provided", func() {
+			It("should write output to file instead of stdout", func() {
+				_, cmd = NewDiscoverCloudFoundryCommand(log)
+				cmd.SetOut(&out)
+				cmd.SetErr(&err)
+				cmd.SetArgs([]string{"--input", manifestPath, "--output-dir", outputPath})
+
+				executeErr := cmd.Execute()
+
+				Expect(executeErr).To(Succeed())
+				Expect(out.String()).To(BeEmpty()) // No stdout output
+
+				// Verify file was created
+				files := getOutputFiles(outputPath)
+				Expect(files).To(HaveLen(1))
+
+				// Verify file content
+				content := readOutputFile(outputPath, files[0].Name())
+				expectedOutput := getExpectedYAMLOutput()
+				Expect(strings.TrimSpace(content)).To(Equal(strings.TrimSpace(expectedOutput)))
+			})
 		})
 	})
 
-	Context("when output-dir flag is provided", func() {
-		It("should write output to file instead of stdout", func() {
-			_, cmd = NewDiscoverCloudFoundryCommand(log)
-			cmd.SetOut(&out)
-			cmd.SetErr(&err)
-			cmd.SetArgs([]string{"--input", manifestPath, "--output-dir", outputPath})
+	Context("when processing manifests with secrets", func() {
 
-			executeErr := cmd.Execute()
+		Context("conceal sensitive data flag is enabled", func() {
+			var manifestWithSecretsPath string
 
-			Expect(executeErr).To(Succeed())
-			Expect(out.String()).To(BeEmpty()) // No stdout output
+			BeforeEach(func() {
+				manifestWithSecretsPath = createManifestWithSecrets(tempDir)
+			})
+			AfterEach(func() {
+				os.RemoveAll(outputPath)
+			})
+			It("should output secrets to stdout along with manifest content", func() {
+				_, cmd = NewDiscoverCloudFoundryCommand(log)
+				cmd.SetOut(&out)
+				cmd.SetErr(&err)
+				cmd.SetArgs([]string{"--input", manifestWithSecretsPath, "--conceal-sensitive-data"})
 
-			// Verify file was created
-			files := getOutputFiles(outputPath)
-			Expect(files).To(HaveLen(1))
+				executeErr := cmd.Execute()
 
-			// Verify file content
-			content := readOutputFile(outputPath, files[0].Name())
-			expectedOutput := getExpectedYAMLOutput()
-			Expect(strings.TrimSpace(content)).To(Equal(strings.TrimSpace(expectedOutput)))
-		})
-	})
+				Expect(executeErr).To(Succeed())
+				output := out.String()
 
-	Context("when processing manifests with secrets and conceal sensitive data flag is enabled", func() {
-		var manifestWithSecretsPath string
+				// Verify content section is present
+				Expect(output).To(ContainSubstring("--- Content Section ---"))
+				Expect(output).To(ContainSubstring("test-app-with-sensitive-data"))
 
-		BeforeEach(func() {
-			manifestWithSecretsPath = createManifestWithSecrets(tempDir)
-		})
-		AfterEach(func() {
-			os.RemoveAll(outputPath)
-		})
-		It("should output secrets to stdout along with manifest content", func() {
-			_, cmd = NewDiscoverCloudFoundryCommand(log)
-			cmd.SetOut(&out)
-			cmd.SetErr(&err)
-			cmd.SetArgs([]string{"--input", manifestWithSecretsPath, "--conceal-sensitive-data"})
+				// Verify secrets section is present
+				Expect(output).To(ContainSubstring("--- Secrets Section ---"))
+				Expect(output).To(ContainSubstring("docker-registry-user"))
+			})
 
-			executeErr := cmd.Execute()
+			It("should write secrets to separate file when output-dir is specified", func() {
+				_, cmd = NewDiscoverCloudFoundryCommand(log)
+				cmd.SetOut(&out)
+				cmd.SetErr(&err)
+				cmd.SetArgs([]string{"--input", manifestWithSecretsPath, "--output-dir", outputPath, "--conceal-sensitive-data"})
 
-			Expect(executeErr).To(Succeed())
-			output := out.String()
+				executeErr := cmd.Execute()
 
-			// Verify content section is present
-			Expect(output).To(ContainSubstring("--- Content Section ---"))
-			Expect(output).To(ContainSubstring("test-app-with-sensitive-data"))
+				Expect(executeErr).To(Succeed())
+				Expect(out.String()).To(BeEmpty()) // No stdout output
 
-			// Verify secrets section is present
-			Expect(output).To(ContainSubstring("--- Secrets Section ---"))
-			Expect(output).To(ContainSubstring("docker-registry-user"))
-		})
+				// Verify both files were created
+				files := getOutputFiles(outputPath)
+				Expect(files).To(HaveLen(2))
 
-		It("should write secrets to separate file when output-dir is specified", func() {
-			_, cmd = NewDiscoverCloudFoundryCommand(log)
-			cmd.SetOut(&out)
-			cmd.SetErr(&err)
-			cmd.SetArgs([]string{"--input", manifestWithSecretsPath, "--output-dir", outputPath, "--conceal-sensitive-data"})
-
-			executeErr := cmd.Execute()
-
-			Expect(executeErr).To(Succeed())
-			Expect(out.String()).To(BeEmpty()) // No stdout output
-
-			// Verify both files were created
-			files := getOutputFiles(outputPath)
-			Expect(files).To(HaveLen(2))
-
-			// Find manifest and secrets files
-			var manifestFile, secretsFile string
-			for _, file := range files {
-				if strings.Contains(file.Name(), "discover_manifest") {
-					manifestFile = file.Name()
-				} else if strings.Contains(file.Name(), "secrets") {
-					secretsFile = file.Name()
+				// Find manifest and secrets files
+				var manifestFile, secretsFile string
+				for _, file := range files {
+					if strings.Contains(file.Name(), "discover_manifest") {
+						manifestFile = file.Name()
+					} else if strings.Contains(file.Name(), "secrets") {
+						secretsFile = file.Name()
+					}
 				}
-			}
 
-			Expect(manifestFile).NotTo(BeEmpty())
-			Expect(secretsFile).NotTo(BeEmpty())
+				Expect(manifestFile).NotTo(BeEmpty())
+				Expect(secretsFile).NotTo(BeEmpty())
 
-			// Verify manifest content
-			manifestContent := readOutputFile(outputPath, manifestFile)
-			Expect(manifestContent).ToNot(BeEmpty())
-			Expect(manifestContent).To(ContainSubstring("test-app-with-sensitive-data"))
+				// Verify manifest content
+				manifestContent := readOutputFile(outputPath, manifestFile)
+				Expect(manifestContent).ToNot(BeEmpty())
+				Expect(manifestContent).To(ContainSubstring("test-app-with-sensitive-data"))
 
-			// Verify secrets content
-			secretsContent := readOutputFile(outputPath, secretsFile)
-			Expect(secretsContent).ToNot(BeEmpty())
-			Expect(secretsContent).To(ContainSubstring("docker-registry-user"))
+				// Verify secrets content
+				secretsContent := readOutputFile(outputPath, secretsFile)
+				Expect(secretsContent).ToNot(BeEmpty())
+				Expect(secretsContent).To(ContainSubstring("docker-registry-user"))
+			})
+
+			It("should handle manifests with no secrets gracefully", func() {
+				_, cmd = NewDiscoverCloudFoundryCommand(log)
+				cmd.SetOut(&out)
+				cmd.SetErr(&err)
+				cmd.SetArgs([]string{"--input", manifestPath, "--output-dir", outputPath, "--conceal-sensitive-data"})
+
+				executeErr := cmd.Execute()
+
+				Expect(executeErr).To(Succeed())
+
+				// Verify only manifest file was created (no secrets file)
+				files := getOutputFiles(outputPath)
+				Expect(files).To(HaveLen(1))
+
+				// Verify it's the manifest file
+				fileName := files[0].Name()
+				Expect(fileName).To(ContainSubstring("discover_manifest"))
+				Expect(fileName).NotTo(ContainSubstring("secrets"))
+			})
+
+			It("should not output secrets section to stdout when manifest has no secrets", func() {
+				_, cmd = NewDiscoverCloudFoundryCommand(log)
+				cmd.SetOut(&out)
+				cmd.SetErr(&err)
+				cmd.SetArgs([]string{"--input", manifestPath, "--conceal-sensitive-data"})
+
+				executeErr := cmd.Execute()
+
+				Expect(executeErr).To(Succeed())
+				output := out.String()
+
+				// Verify content section is present
+				Expect(output).To(ContainSubstring("--- Content Section ---"))
+				Expect(output).To(ContainSubstring("test-app"))
+
+				// Verify secrets section is NOT present
+				Expect(output).NotTo(ContainSubstring("--- Secrets Section ---"))
+			})
 		})
 
-		It("should handle manifests with no secrets gracefully", func() {
-			_, cmd = NewDiscoverCloudFoundryCommand(log)
-			cmd.SetOut(&out)
-			cmd.SetErr(&err)
-			cmd.SetArgs([]string{"--input", manifestPath, "--output-dir", outputPath, "--conceal-sensitive-data"})
+		Context("conceal sensitive data flag is disabled", func() {
+			var manifestWithSecretsPath string
 
-			executeErr := cmd.Execute()
+			BeforeEach(func() {
+				manifestWithSecretsPath = createManifestWithSecrets(tempDir)
+			})
+			AfterEach(func() {
+				os.RemoveAll(outputPath)
+			})
+			It("should not output secrets to stdout along with manifest content", func() {
+				_, cmd = NewDiscoverCloudFoundryCommand(log)
+				cmd.SetOut(&out)
+				cmd.SetErr(&err)
+				cmd.SetArgs([]string{"--input", manifestWithSecretsPath})
 
-			Expect(executeErr).To(Succeed())
+				executeErr := cmd.Execute()
 
-			// Verify only manifest file was created (no secrets file)
-			files := getOutputFiles(outputPath)
-			Expect(files).To(HaveLen(1))
+				Expect(executeErr).To(Succeed())
+				output := out.String()
 
-			// Verify it's the manifest file
-			fileName := files[0].Name()
-			Expect(fileName).To(ContainSubstring("discover_manifest"))
-			Expect(fileName).NotTo(ContainSubstring("secrets"))
-		})
+				// Verify content section is present
+				Expect(output).To(ContainSubstring("--- Content Section ---"))
+				Expect(output).To(ContainSubstring("test-app-with-sensitive-data"))
 
-		It("should not output secrets section to stdout when manifest has no secrets", func() {
-			_, cmd = NewDiscoverCloudFoundryCommand(log)
-			cmd.SetOut(&out)
-			cmd.SetErr(&err)
-			cmd.SetArgs([]string{"--input", manifestPath, "--conceal-sensitive-data"})
+				// Verify secrets section is present
+				Expect(output).NotTo(ContainSubstring("--- Secrets Section ---"))
+			})
 
-			executeErr := cmd.Execute()
+			It("should not write secrets to separate file when output-dir is specified", func() {
+				_, cmd = NewDiscoverCloudFoundryCommand(log)
+				cmd.SetOut(&out)
+				cmd.SetErr(&err)
+				cmd.SetArgs([]string{"--input", manifestWithSecretsPath, "--output-dir", outputPath})
 
-			Expect(executeErr).To(Succeed())
-			output := out.String()
+				executeErr := cmd.Execute()
 
-			// Verify content section is present
-			Expect(output).To(ContainSubstring("--- Content Section ---"))
-			Expect(output).To(ContainSubstring("test-app"))
+				Expect(executeErr).To(Succeed())
+				Expect(out.String()).To(BeEmpty()) // No stdout output
 
-			// Verify secrets section is NOT present
-			Expect(output).NotTo(ContainSubstring("--- Secrets Section ---"))
-		})
-	})
+				// Verify both files were created
+				files := getOutputFiles(outputPath)
+				Expect(files).To(HaveLen(1))
 
-	Context("when processing manifests with secrets and conceal sensitive data flag is disabled", func() {
-		var manifestWithSecretsPath string
-
-		BeforeEach(func() {
-			manifestWithSecretsPath = createManifestWithSecrets(tempDir)
-		})
-		AfterEach(func() {
-			os.RemoveAll(outputPath)
-		})
-		It("should not output secrets to stdout along with manifest content", func() {
-			_, cmd = NewDiscoverCloudFoundryCommand(log)
-			cmd.SetOut(&out)
-			cmd.SetErr(&err)
-			cmd.SetArgs([]string{"--input", manifestWithSecretsPath})
-
-			executeErr := cmd.Execute()
-
-			Expect(executeErr).To(Succeed())
-			output := out.String()
-
-			// Verify content section is present
-			Expect(output).To(ContainSubstring("--- Content Section ---"))
-			Expect(output).To(ContainSubstring("test-app-with-sensitive-data"))
-
-			// Verify secrets section is present
-			Expect(output).NotTo(ContainSubstring("--- Secrets Section ---"))
-		})
-
-		It("should not write secrets to separate file when output-dir is specified", func() {
-			_, cmd = NewDiscoverCloudFoundryCommand(log)
-			cmd.SetOut(&out)
-			cmd.SetErr(&err)
-			cmd.SetArgs([]string{"--input", manifestWithSecretsPath, "--output-dir", outputPath})
-
-			executeErr := cmd.Execute()
-
-			Expect(executeErr).To(Succeed())
-			Expect(out.String()).To(BeEmpty()) // No stdout output
-
-			// Verify both files were created
-			files := getOutputFiles(outputPath)
-			Expect(files).To(HaveLen(1))
-
-			// Find manifest and secrets files
-			var manifestFile string
-			for _, file := range files {
-				Expect(file.Name()).NotTo(ContainSubstring("secrets"))
-				if strings.Contains(file.Name(), "discover_manifest") {
-					manifestFile = file.Name()
+				// Find manifest and secrets files
+				var manifestFile string
+				for _, file := range files {
+					Expect(file.Name()).NotTo(ContainSubstring("secrets"))
+					if strings.Contains(file.Name(), "discover_manifest") {
+						manifestFile = file.Name()
+					}
 				}
-			}
 
-			Expect(manifestFile).NotTo(BeEmpty())
+				Expect(manifestFile).NotTo(BeEmpty())
 
-			// Verify manifest content
-			manifestContent := readOutputFile(outputPath, manifestFile)
-			Expect(manifestContent).ToNot(BeEmpty())
-			Expect(manifestContent).To(ContainSubstring("test-app-with-sensitive-data"))
+				// Verify manifest content
+				manifestContent := readOutputFile(outputPath, manifestFile)
+				Expect(manifestContent).ToNot(BeEmpty())
+				Expect(manifestContent).To(ContainSubstring("test-app-with-sensitive-data"))
 
-		})
+			})
 
-		It("should handle manifests with no secrets gracefully", func() {
-			_, cmd = NewDiscoverCloudFoundryCommand(log)
-			cmd.SetOut(&out)
-			cmd.SetErr(&err)
-			cmd.SetArgs([]string{"--input", manifestPath, "--output-dir", outputPath})
+			It("should handle manifests with no secrets gracefully", func() {
+				_, cmd = NewDiscoverCloudFoundryCommand(log)
+				cmd.SetOut(&out)
+				cmd.SetErr(&err)
+				cmd.SetArgs([]string{"--input", manifestPath, "--output-dir", outputPath})
 
-			executeErr := cmd.Execute()
+				executeErr := cmd.Execute()
 
-			Expect(executeErr).To(Succeed())
+				Expect(executeErr).To(Succeed())
 
-			// Verify only manifest file was created (no secrets file)
-			files := getOutputFiles(outputPath)
-			Expect(files).To(HaveLen(1))
+				// Verify only manifest file was created (no secrets file)
+				files := getOutputFiles(outputPath)
+				Expect(files).To(HaveLen(1))
 
-			// Verify it's the manifest file
-			fileName := files[0].Name()
-			Expect(fileName).To(ContainSubstring("discover_manifest"))
-			Expect(fileName).NotTo(ContainSubstring("secrets"))
-		})
+				// Verify it's the manifest file
+				fileName := files[0].Name()
+				Expect(fileName).To(ContainSubstring("discover_manifest"))
+				Expect(fileName).NotTo(ContainSubstring("secrets"))
+			})
 
-		It("should not output secrets section to stdout when manifest has no secrets", func() {
-			_, cmd = NewDiscoverCloudFoundryCommand(log)
-			cmd.SetOut(&out)
-			cmd.SetErr(&err)
-			cmd.SetArgs([]string{"--input", manifestPath})
+			It("should not output secrets section to stdout when manifest has no secrets", func() {
+				_, cmd = NewDiscoverCloudFoundryCommand(log)
+				cmd.SetOut(&out)
+				cmd.SetErr(&err)
+				cmd.SetArgs([]string{"--input", manifestPath})
 
-			executeErr := cmd.Execute()
+				executeErr := cmd.Execute()
 
-			Expect(executeErr).To(Succeed())
-			output := out.String()
+				Expect(executeErr).To(Succeed())
+				output := out.String()
 
-			// Verify content section is present
-			Expect(output).To(ContainSubstring("--- Content Section ---"))
-			Expect(output).To(ContainSubstring("test-app"))
+				// Verify content section is present
+				Expect(output).To(ContainSubstring("--- Content Section ---"))
+				Expect(output).To(ContainSubstring("test-app"))
 
-			// Verify secrets section is NOT present
-			Expect(output).NotTo(ContainSubstring("--- Secrets Section ---"))
-		})
-	})
-
-	Context("when required flags are missing", func() {
-		It("should return error when input flag is not provided", func() {
-			_, cmd = NewDiscoverCloudFoundryCommand(log)
-			cmd.SetOut(&out)
-			cmd.SetErr(&err)
-			cmd.SetArgs([]string{})
-
-			executeErr := cmd.Execute()
-
-			Expect(executeErr).To(HaveOccurred())
-			Expect(err.String()).To(ContainSubstring("Error: input flag is required"))
-		})
-
-		It("should return error when use-live-connection is true but no spaces provided", func() {
-			_, cmd = NewDiscoverCloudFoundryCommand(log)
-			cmd.SetOut(&out)
-			cmd.SetErr(&err)
-			cmd.SetArgs([]string{"--use-live-connection"})
-
-			executeErr := cmd.Execute()
-
-			Expect(executeErr).To(HaveOccurred())
-			Expect(executeErr.Error()).To(ContainSubstring("at least one space is required"))
+				// Verify secrets section is NOT present
+				Expect(output).NotTo(ContainSubstring("--- Secrets Section ---"))
+			})
 		})
 	})
 
+	Context("when list-apps flag is provided", func() {
+		Context("when using live discover", func() {
+			It("should list apps in the spaces", func() {
+				mockProv := &mockProvider{
+					DiscoverFunc: func(raw any) (*pTypes.DiscoverResult, error) {
+						return &pTypes.DiscoverResult{}, nil
+					},
+					ListAppsFunc: func() (map[string][]any, error) {
+						return map[string][]any{
+							"space1": {
+								cfProvider.AppReference{SpaceName: "space1", AppName: "app1"},
+								cfProvider.AppReference{SpaceName: "space1", AppName: "app2"},
+							},
+							"space2": {
+								cfProvider.AppReference{SpaceName: "space2", AppName: "app1"},
+							},
+						}, nil
+					},
+				}
+
+				var out bytes.Buffer
+				contentWriter := bufio.NewWriter(&out)
+
+				err := listApplicationsLive(mockProv, contentWriter)
+				Expect(err).To(Succeed())
+
+				contentWriter.Flush()
+
+				output := out.String()
+				Expect(output).To(ContainSubstring("Space: space1"))
+				Expect(output).To(ContainSubstring("  - app1"))
+				Expect(output).To(ContainSubstring("  - app2"))
+				Expect(output).To(ContainSubstring("Space: space2"))
+				Expect(output).To(ContainSubstring("  - app1"))
+			})
+			It("should handle empty spaces (no apps)", func() {
+				mockProv := &mockProvider{
+					ListAppsFunc: func() (map[string][]any, error) {
+						return map[string][]any{
+							"space1": {},
+							"space2": {},
+						}, nil
+					},
+				}
+
+				var out bytes.Buffer
+				contentWriter := bufio.NewWriter(&out)
+
+				err := listApplicationsLive(mockProv, contentWriter)
+				Expect(err).To(Succeed())
+
+				contentWriter.Flush()
+				output := out.String()
+
+				// Should print spaces but no apps under them
+				Expect(output).To(ContainSubstring("Space: space1"))
+				Expect(output).To(ContainSubstring("Space: space2"))
+				Expect(output).NotTo(ContainSubstring("- ")) // No app entries
+			})
+
+			It("should return error if ListApps returns an error", func() {
+				mockProv := &mockProvider{
+					ListAppsFunc: func() (map[string][]any, error) {
+						return nil, fmt.Errorf("some error")
+					},
+				}
+
+				var out bytes.Buffer
+				contentWriter := bufio.NewWriter(&out)
+
+				err := listApplicationsLive(mockProv, contentWriter)
+				Expect(err).To(MatchError("failed to list apps by space: some error"))
+			})
+
+			It("should handle no spaces returned (empty map)", func() {
+				mockProv := &mockProvider{
+					ListAppsFunc: func() (map[string][]any, error) {
+						return map[string][]any{}, nil
+					},
+				}
+
+				var out bytes.Buffer
+				contentWriter := bufio.NewWriter(&out)
+
+				err := listApplicationsLive(mockProv, contentWriter)
+				Expect(err).To(Succeed())
+
+				contentWriter.Flush()
+				output := out.String()
+				Expect(output).To(BeEmpty())
+			})
+		})
+		Context("when using local discover", func() {
+			It("lists a single app from a single manifest", func() {
+
+				var out bytes.Buffer
+				contentWriter := bufio.NewWriter(&out)
+				tempDir := createTempDir()
+				defer os.RemoveAll(tempDir)
+
+				manifestPath = createTestManifest(tempDir)
+				err := listApplicationsLocal(tempDir, contentWriter)
+				Expect(err).ToNot(HaveOccurred())
+
+				contentWriter.Flush()
+
+				output := out.String()
+				Expect(output).To(ContainSubstring("Space: local"))
+				Expect(output).To(ContainSubstring("  - test-app"))
+			})
+			It("lists multiple apps from multiple manifests", func() {
+
+				var out bytes.Buffer
+				contentWriter := bufio.NewWriter(&out)
+				tempDir := createTempDir()
+				defer os.RemoveAll(tempDir)
+				createMultipleManifests(tempDir, 3)
+				err := listApplicationsLocal(tempDir, contentWriter)
+				Expect(err).ToNot(HaveOccurred())
+
+				contentWriter.Flush()
+
+				output := out.String()
+				Expect(output).To(ContainSubstring("Space: local"))
+				Expect(output).To(ContainSubstring("  - test-app-0"))
+				Expect(output).To(ContainSubstring("  - test-app-1"))
+				Expect(output).To(ContainSubstring("  - test-app-2"))
+			})
+		})
+
+	})
 	Context("when using live discovery", func() {
 		It("should validate that spaces are provided", func() {
 			_, cmd = NewDiscoverCloudFoundryCommand(log)
@@ -508,168 +633,182 @@ var _ = Describe("Discover command", func() {
 		})
 	})
 
-	Context("when flag combinations are invalid", func() {
-		It("should reject mutually exclusive flags: use-live-connection and input", func() {
+	Context("when performing local discover", func() {
+
+		It("should discover manifest and print to stdout by default", func() {
 			_, cmd = NewDiscoverCloudFoundryCommand(log)
 			cmd.SetOut(&out)
 			cmd.SetErr(&err)
-			cmd.SetArgs([]string{"--use-live-connection", "--spaces", "test-space",
-				"--cf-config", "../../../../test-data/asset_generation/discover", "--input", manifestPath})
-
-			executeErr := cmd.Execute()
-
-			Expect(executeErr).To(HaveOccurred())
-			Expect(executeErr.Error()).To(ContainSubstring("[input use-live-connection] were all set"))
-		})
-	})
-
-	Context("when input file does not exist", func() {
-		It("should return error for nonexistent file", func() {
-			_, cmd = NewDiscoverCloudFoundryCommand(log)
-			cmd.SetOut(&out)
-			cmd.SetErr(&err)
-			cmd.SetArgs([]string{"--input", "nonexistent.yaml"})
-
-			executeErr := cmd.Execute()
-
-			Expect(executeErr).To(HaveOccurred())
-			Expect(executeErr.Error()).To(ContainSubstring("no such file or directory"))
-		})
-	})
-
-	Context("when processing directories", func() {
-		It("should process all manifest files in a directory", func() {
-			// Create multiple manifest files in a directory
-			manifestDir := filepath.Join(tempDir, "manifests")
-			Expect(os.Mkdir(manifestDir, 0755)).To(Succeed())
-
-			manifest1 := filepath.Join(manifestDir, "app1.yaml")
-			manifest2 := filepath.Join(manifestDir, "app2.yaml")
-
-			Expect(os.WriteFile(manifest1, []byte("name: app1\nmemory: 256M"), 0644)).To(Succeed())
-			Expect(os.WriteFile(manifest2, []byte("name: app2\nmemory: 512M"), 0644)).To(Succeed())
-
-			_, cmd = NewDiscoverCloudFoundryCommand(log)
-			cmd.SetOut(&out)
-			cmd.SetErr(&err)
-			cmd.SetArgs([]string{"--input", manifestDir})
+			cmd.SetArgs([]string{"--input", manifestPath})
 
 			executeErr := cmd.Execute()
 
 			Expect(executeErr).To(Succeed())
-			Expect(out.String()).To(ContainSubstring("app1"))
-			Expect(out.String()).To(ContainSubstring("app2"))
+			Expect(out.String()).To(ContainSubstring("test-app"))
+			Expect(err.String()).To(BeEmpty())
 		})
 
-		It("should handle empty directories gracefully", func() {
-			emptyDir := filepath.Join(tempDir, "empty")
-			Expect(os.Mkdir(emptyDir, 0755)).To(Succeed())
-
+		It("should produce correct YAML output format", func() {
 			_, cmd = NewDiscoverCloudFoundryCommand(log)
 			cmd.SetOut(&out)
 			cmd.SetErr(&err)
-			cmd.SetArgs([]string{"--input", emptyDir})
+			cmd.SetArgs([]string{"--input", manifestPath})
 
 			executeErr := cmd.Execute()
 
 			Expect(executeErr).To(Succeed())
-			Expect(out.String()).To(BeEmpty())
+			expectedOutput := getExpectedYAMLOutput()
+			Expect(strings.TrimSpace(out.String())).To(Equal(strings.TrimSpace("--- Content Section ---\n" + expectedOutput)))
 		})
 
-		It("should skip nested directories and process only files", func() {
-			manifestDir := filepath.Join(tempDir, "manifests")
-			nestedDir := filepath.Join(manifestDir, "nested")
-			Expect(os.MkdirAll(nestedDir, 0755)).To(Succeed())
+		Context("when input file does not exist", func() {
+			It("should return error for nonexistent file", func() {
+				_, cmd = NewDiscoverCloudFoundryCommand(log)
+				cmd.SetOut(&out)
+				cmd.SetErr(&err)
+				cmd.SetArgs([]string{"--input", "nonexistent.yaml"})
 
-			// Create file in main directory
-			mainFile := filepath.Join(manifestDir, "main-app.yaml")
-			Expect(os.WriteFile(mainFile, []byte("name: main-app\nmemory: 256M"), 0644)).To(Succeed())
+				executeErr := cmd.Execute()
 
-			// Create file in nested directory (should be skipped)
-			nestedFile := filepath.Join(nestedDir, "nested-app.yaml")
-			Expect(os.WriteFile(nestedFile, []byte("name: nested-app\nmemory: 256M"), 0644)).To(Succeed())
-
-			_, cmd = NewDiscoverCloudFoundryCommand(log)
-			cmd.SetOut(&out)
-			cmd.SetErr(&err)
-			cmd.SetArgs([]string{"--input", manifestDir})
-
-			executeErr := cmd.Execute()
-
-			Expect(executeErr).To(Succeed())
-			Expect(out.String()).To(ContainSubstring("main-app"))
-			Expect(out.String()).NotTo(ContainSubstring("nested-app"))
-		})
-	})
-
-	Context("when using app-name filter with file-based discovery", func() {
-		It("should filter apps by name when app-name flag is provided", func() {
-			// Create directory with multiple apps
-			manifestDir := filepath.Join(tempDir, "manifests")
-			Expect(os.Mkdir(manifestDir, 0755)).To(Succeed())
-
-			manifest1 := filepath.Join(manifestDir, "app1.yaml")
-			manifest2 := filepath.Join(manifestDir, "app2.yaml")
-
-			Expect(os.WriteFile(manifest1, []byte("name: target-app\nmemory: 256M"), 0644)).To(Succeed())
-			Expect(os.WriteFile(manifest2, []byte("name: other-app\nmemory: 512M"), 0644)).To(Succeed())
-
-			_, cmd = NewDiscoverCloudFoundryCommand(log)
-			cmd.SetOut(&out)
-			cmd.SetErr(&err)
-			cmd.SetArgs([]string{"--input", manifestDir, "--app-name", "target-app"})
-
-			executeErr := cmd.Execute()
-
-			Expect(executeErr).To(Succeed())
-			Expect(out.String()).To(ContainSubstring("target-app"))
-			Expect(out.String()).NotTo(ContainSubstring("other-app"))
+				Expect(executeErr).To(HaveOccurred())
+				Expect(executeErr.Error()).To(ContainSubstring("no such file or directory"))
+			})
 		})
 
-		It("should return no results when app-name doesn't match any apps", func() {
-			_, cmd = NewDiscoverCloudFoundryCommand(log)
-			cmd.SetOut(&out)
-			cmd.SetErr(&err)
-			cmd.SetArgs([]string{"--input", manifestPath, "--app-name", "non-existent-app"})
+		Context("when processing directories", func() {
+			It("should process all manifest files in a directory", func() {
+				// Create multiple manifest files in a directory
+				manifestDir := filepath.Join(tempDir, "manifests")
+				Expect(os.Mkdir(manifestDir, 0755)).To(Succeed())
 
-			executeErr := cmd.Execute()
+				manifest1 := filepath.Join(manifestDir, "app1.yaml")
+				manifest2 := filepath.Join(manifestDir, "app2.yaml")
 
-			Expect(executeErr).To(Succeed())
-			Expect(out.String()).To(BeEmpty())
+				Expect(os.WriteFile(manifest1, []byte("name: app1\nmemory: 256M"), 0644)).To(Succeed())
+				Expect(os.WriteFile(manifest2, []byte("name: app2\nmemory: 512M"), 0644)).To(Succeed())
+
+				_, cmd = NewDiscoverCloudFoundryCommand(log)
+				cmd.SetOut(&out)
+				cmd.SetErr(&err)
+				cmd.SetArgs([]string{"--input", manifestDir})
+
+				executeErr := cmd.Execute()
+
+				Expect(executeErr).To(Succeed())
+				Expect(out.String()).To(ContainSubstring("app1"))
+				Expect(out.String()).To(ContainSubstring("app2"))
+			})
+
+			It("should handle empty directories gracefully", func() {
+				emptyDir := filepath.Join(tempDir, "empty")
+				Expect(os.Mkdir(emptyDir, 0755)).To(Succeed())
+
+				_, cmd = NewDiscoverCloudFoundryCommand(log)
+				cmd.SetOut(&out)
+				cmd.SetErr(&err)
+				cmd.SetArgs([]string{"--input", emptyDir})
+
+				executeErr := cmd.Execute()
+
+				Expect(executeErr).To(Succeed())
+				Expect(out.String()).To(BeEmpty())
+			})
+
+			It("should skip nested directories and process only files", func() {
+				manifestDir := filepath.Join(tempDir, "manifests")
+				nestedDir := filepath.Join(manifestDir, "nested")
+				Expect(os.MkdirAll(nestedDir, 0755)).To(Succeed())
+
+				// Create file in main directory
+				mainFile := filepath.Join(manifestDir, "main-app.yaml")
+				Expect(os.WriteFile(mainFile, []byte("name: main-app\nmemory: 256M"), 0644)).To(Succeed())
+
+				// Create file in nested directory (should be skipped)
+				nestedFile := filepath.Join(nestedDir, "nested-app.yaml")
+				Expect(os.WriteFile(nestedFile, []byte("name: nested-app\nmemory: 256M"), 0644)).To(Succeed())
+
+				_, cmd = NewDiscoverCloudFoundryCommand(log)
+				cmd.SetOut(&out)
+				cmd.SetErr(&err)
+				cmd.SetArgs([]string{"--input", manifestDir})
+
+				executeErr := cmd.Execute()
+
+				Expect(executeErr).To(Succeed())
+				Expect(out.String()).To(ContainSubstring("main-app"))
+				Expect(out.String()).NotTo(ContainSubstring("nested-app"))
+			})
 		})
-	})
 
-	Context("when output directory has issues", func() {
-		It("should return error when output directory cannot be created", func() {
-			// Try to create output directory in a non-existent parent path
-			invalidOutputPath := "/nonexistent/path/output"
-			_, cmd = NewDiscoverCloudFoundryCommand(log)
-			cmd.SetOut(&out)
-			cmd.SetErr(&err)
-			cmd.SetArgs([]string{"--input", manifestPath, "--output-dir", invalidOutputPath})
+		Context("when using app-name filter with file-based discovery", func() {
+			It("should filter apps by name when app-name flag is provided", func() {
+				// Create directory with multiple apps
+				manifestDir := filepath.Join(tempDir, "manifests")
+				Expect(os.Mkdir(manifestDir, 0755)).To(Succeed())
 
-			executeErr := cmd.Execute()
+				manifest1 := filepath.Join(manifestDir, "app1.yaml")
+				manifest2 := filepath.Join(manifestDir, "app2.yaml")
 
-			Expect(executeErr).To(HaveOccurred())
-			Expect(executeErr.Error()).To(ContainSubstring("failed to create output folder"))
+				Expect(os.WriteFile(manifest1, []byte("name: target-app\nmemory: 256M"), 0644)).To(Succeed())
+				Expect(os.WriteFile(manifest2, []byte("name: other-app\nmemory: 512M"), 0644)).To(Succeed())
+
+				_, cmd = NewDiscoverCloudFoundryCommand(log)
+				cmd.SetOut(&out)
+				cmd.SetErr(&err)
+				cmd.SetArgs([]string{"--input", manifestDir, "--app-name", "target-app"})
+
+				executeErr := cmd.Execute()
+
+				Expect(executeErr).To(Succeed())
+				Expect(out.String()).To(ContainSubstring("target-app"))
+				Expect(out.String()).NotTo(ContainSubstring("other-app"))
+			})
+
+			It("should return no results when app-name doesn't match any apps", func() {
+				_, cmd = NewDiscoverCloudFoundryCommand(log)
+				cmd.SetOut(&out)
+				cmd.SetErr(&err)
+				cmd.SetArgs([]string{"--input", manifestPath, "--app-name", "non-existent-app"})
+
+				executeErr := cmd.Execute()
+
+				Expect(executeErr).To(Succeed())
+				Expect(out.String()).To(BeEmpty())
+			})
 		})
-	})
 
-	Context("when processing files with permission issues", func() {
-		It("should return error when manifest file cannot be read", func() {
-			// Create a file with no read permissions
-			unreadableFile := filepath.Join(tempDir, "unreadable.yaml")
-			Expect(os.WriteFile(unreadableFile, []byte("name: test-app"), 0000)).To(Succeed())
+		Context("when output directory has issues", func() {
+			It("should return error when output directory cannot be created", func() {
+				// Try to create output directory in a non-existent parent path
+				invalidOutputPath := "/nonexistent/path/output"
+				_, cmd = NewDiscoverCloudFoundryCommand(log)
+				cmd.SetOut(&out)
+				cmd.SetErr(&err)
+				cmd.SetArgs([]string{"--input", manifestPath, "--output-dir", invalidOutputPath})
 
-			_, cmd = NewDiscoverCloudFoundryCommand(log)
-			cmd.SetOut(&out)
-			cmd.SetErr(&err)
-			cmd.SetArgs([]string{"--input", unreadableFile})
+				executeErr := cmd.Execute()
 
-			executeErr := cmd.Execute()
+				Expect(executeErr).To(HaveOccurred())
+				Expect(executeErr.Error()).To(ContainSubstring("failed to create output folder"))
+			})
+		})
 
-			Expect(executeErr).To(HaveOccurred())
-			Expect(executeErr.Error()).To(ContainSubstring("permission denied"))
+		Context("when processing files with permission issues", func() {
+			It("should return error when manifest file cannot be read", func() {
+				// Create a file with no read permissions
+				unreadableFile := filepath.Join(tempDir, "unreadable.yaml")
+				Expect(os.WriteFile(unreadableFile, []byte("name: test-app"), 0000)).To(Succeed())
+
+				_, cmd = NewDiscoverCloudFoundryCommand(log)
+				cmd.SetOut(&out)
+				cmd.SetErr(&err)
+				cmd.SetArgs([]string{"--input", unreadableFile})
+
+				executeErr := cmd.Execute()
+
+				Expect(executeErr).To(HaveOccurred())
+				Expect(executeErr.Error()).To(ContainSubstring("permission denied"))
+			})
 		})
 	})
 })
@@ -682,13 +821,24 @@ func createTempDir() string {
 	return tempDir
 }
 
-func createTestManifest(tempDir string) string {
-	manifestContent := []byte(`---
-name: test-app
+func createMultipleManifests(tempDir string, howmany int) {
+	for i := 0; i < howmany; i++ {
+		createTestManifest(tempDir, strconv.Itoa(i))
+	}
+}
+func createTestManifest(tempDir string, suffix ...string) string {
+	appName := "test-app"
+	suffixVal := ""
+	if len(suffix) > 0 && suffix[0] != "" {
+		suffixVal = "-" + suffix[0]
+	}
+	manifestContent := []byte(fmt.Sprintf(`---
+name: %s
 memory: 256M
 instances: 1
-`)
-	manifestPath := filepath.Join(tempDir, "manifest.yaml")
+`, appName+suffixVal))
+
+	manifestPath := filepath.Join(tempDir, "manifest"+suffixVal+".yaml")
 	Expect(os.WriteFile(manifestPath, manifestContent, 0644)).To(Succeed())
 	return manifestPath
 }

--- a/cmd/asset_generation/discover/cloud_foundry/mocks.go
+++ b/cmd/asset_generation/discover/cloud_foundry/mocks.go
@@ -1,0 +1,24 @@
+package cloud_foundry
+
+import (
+	pTypes "github.com/konveyor/asset-generation/pkg/providers/types/provider"
+)
+
+type mockProvider struct {
+	DiscoverFunc func(RawData any) (*pTypes.DiscoverResult, error)
+	ListAppsFunc func() (map[string][]any, error)
+}
+
+func (m *mockProvider) Discover(raw any) (*pTypes.DiscoverResult, error) {
+	if m.DiscoverFunc != nil {
+		return m.DiscoverFunc(raw)
+	}
+	return nil, nil
+}
+
+func (m *mockProvider) ListApps() (map[string][]any, error) {
+	if m.ListAppsFunc != nil {
+		return m.ListAppsFunc()
+	}
+	return nil, nil
+}

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -51,7 +51,14 @@ static-report
 `kantra discover cloud-foundry --input=<path-to/manifest-yaml>`
 
     For example:
-    `kantra discover cloud-foundry --input=./test-data/asset_generation/discover/cf-sample-app.yaml`
+    `kantra discover cloud-foundry
+    --input=./test-data/asset_generation/discover/cf-sample-app.yaml`
+    
+- Print list of available applications of source platform resources
+`kantra discover cloud-foundry --input=<path-to/manifest-yaml> --list-apps`
+
+    For example:
+    `kantra discover cloud-foundry --input=./test-data/asset_generation/discover/cf-sample-app.yaml --list-apps`
 
 - Output YAML representations of source platform resources in the output directory
 `kantra discover cloud-foundry --input=<path-to/manifest-yaml> --output-dir=<path-to/output-dir>`
@@ -64,6 +71,13 @@ static-report
 
     For example:
     `kantra discover cloud-foundry --input=./test-data/asset_generation/discover/cf-sample-app.yaml --conceal-sensitive-data=true --output-dir=/tmp/output-dir`
+
+- Perform a live discover and print the list of the available applications for
+  each space
+`kantra discover cloud-foundry --use-live-connection --spaces=<space1,space2> --list-apps`
+
+    For example:
+    `kantra discover cloud-foundry --use-live-connection --spaces=space1,space2 --list-apps`
 
 - Perform a live discover and print the YAML representation of source platform resources
 `kantra discover cloud-foundry --use-live-connection --spaces=<space1,space2>`


### PR DESCRIPTION
⚠️ Depends on #505 ⚠️

Add `--list-apps` flag to `discover` sub-command for listing the available application in the source platform.
It works both with local and live discover.

Example output:

```yaml
Space: space-1
  - app-1
  - app-2
Space: space-2
  - app-3
  - app-4
  - app-5
```

Signed-off-by: Gloria Ciavarrini <gciavarrini@redhat.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new flag to list available applications per space during Cloud Foundry discovery, supporting both live and local manifest modes.

* **Documentation**
  * Updated usage instructions and examples to include the new application listing feature and clarified flag defaults.

* **Tests**
  * Expanded and reorganized tests to cover the new listing functionality, flag validation, and output scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->