### PR TITLE
:bug: [MTA-4033] Fix Gradle in containerless mode

### DIFF
--- a/.github/workflows/release-artifacts.yaml
+++ b/.github/workflows/release-artifacts.yaml
@@ -50,18 +50,21 @@ jobs:
         podman cp kantra-download:/usr/local/static-report . && zip -r kantra.linux.${{ matrix.arch }}.zip static-report  
         podman cp kantra-download:/opt/rulesets . && zip -r kantra.linux.${{ matrix.arch }}.zip rulesets
         podman cp kantra-download:/usr/local/etc/maven.default.index . && zip -r kantra.linux.${{ matrix.arch }}.zip maven.default.index
+        podman cp kantra-download:/usr/local/etc/task.gradle . && zip -r kantra.linux.${{ matrix.arch }}.zip task.gradle
               
         podman cp kantra-download:/jdtls . && zip -r kantra.darwin.${{ matrix.arch }}.zip jdtls
         podman cp kantra-download:/bin/fernflower.jar . && zip kantra.darwin.${{ matrix.arch }}.zip fernflower.jar
         podman cp kantra-download:/usr/local/static-report . && zip -r kantra.darwin.${{ matrix.arch }}.zip static-report
         podman cp kantra-download:/opt/rulesets . && zip -r kantra.darwin.${{ matrix.arch }}.zip rulesets
         podman cp kantra-download:/usr/local/etc/maven.default.index . && zip -r kantra.darwin.${{ matrix.arch }}.zip maven.default.index
+        podman cp kantra-download:/usr/local/etc/task.gradle . && zip -r kantra.darwin.${{ matrix.arch }}.zip task.gradle
 
         podman cp kantra-download:/jdtls . && zip -r kantra.windows.${{ matrix.arch }}.zip jdtls
         podman cp kantra-download:/bin/fernflower.jar . && zip kantra.windows.${{ matrix.arch }}.zip fernflower.jar
         podman cp kantra-download:/usr/local/static-report . && zip -r kantra.windows.${{ matrix.arch }}.zip static-report
         podman cp kantra-download:/opt/rulesets . && zip -r kantra.windows.${{ matrix.arch }}.zip rulesets
         podman cp kantra-download:/usr/local/etc/maven.default.index . && zip -r kantra.windows.${{ matrix.arch }}.zip maven.default.index
+        podman cp kantra-download:/usr/local/etc/task.gradle . && zip -r kantra.windows.${{ matrix.arch }}.zip task.gradle
 
     - name: Upload linux binary
       uses: actions/upload-release-asset@v1

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ vendor/
 **/ginkgo.report
 
 kantra
+
+settings.json

--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ Flags:
   -o, --output string                    path to the directory for analysis output
       --overwrite                        overwrite output directory
       --rules stringArray                filename or directory containing rule files. Use multiple times for additional rules: --rules <rule1> --rules <rule2> ...
+      --run-local                        run Java analysis in containerless mode (default true)
       --skip-static-report               do not generate static report
   -s, --source stringArray               source technology to consider for analysis. Use multiple times for additional sources: --source <source1> --source <source2> ...
   -t, --target stringArray               target technology to consider for analysis. Use multiple times for additional targets: --target <target1> --target <target2> ...
@@ -391,6 +392,7 @@ Flags:
 - [Using provider options](./docs/usage.md)
 - [Test runner for YAML rules](./docs/testrunner.md)
 - [Setup dev environment instructions](./hack/README.md#setup-dev-environment-for-asset-generation)
+- [Containerless mode](./docs/containerless.md)
 
 ## Code of Conduct
 

--- a/cmd/analyze-bin.go
+++ b/cmd/analyze-bin.go
@@ -79,17 +79,6 @@ func (a *analyzeCommand) RunAnalysisContainerless(ctx context.Context) error {
 	}
 	defer analysisLog.Close()
 
-	// try to convert any xml rules
-	xmlTempConverted, xmlTempRulesDirs, err := a.ConvertXMLContainerless()
-	if err != nil {
-		a.log.Error(err, "failed to convert xml rules")
-		return err
-	}
-	defer os.RemoveAll(xmlTempConverted)
-	for _, d := range xmlTempRulesDirs {
-		defer os.RemoveAll(d)
-	}
-
 	// clean jdtls dirs after analysis
 	defer func() {
 		if err := a.cleanlsDirs(); err != nil {

--- a/cmd/analyze-bin.go
+++ b/cmd/analyze-bin.go
@@ -79,6 +79,17 @@ func (a *analyzeCommand) RunAnalysisContainerless(ctx context.Context) error {
 	}
 	defer analysisLog.Close()
 
+	// try to convert any xml rules
+	xmlTempConverted, xmlTempRulesDirs, err := a.ConvertXMLContainerless()
+	if err != nil {
+		a.log.Error(err, "failed to convert xml rules")
+		return err
+	}
+	defer os.RemoveAll(xmlTempConverted)
+	for _, d := range xmlTempRulesDirs {
+		defer os.RemoveAll(d)
+	}
+
 	// clean jdtls dirs after analysis
 	defer func() {
 		if err := a.cleanlsDirs(); err != nil {
@@ -420,6 +431,7 @@ func (a *analyzeCommand) createProviderConfigsContainerless(excludedTargetPaths 
 					provider.LspServerPathConfigKey: a.reqMap["jdtls"],
 					"depOpenSourceLabelsFile":       filepath.Join(a.kantraDir, "maven.default.index"),
 					"disableMavenSearch":            a.disableMavenSearch,
+					"gradleSourcesTaskFile":         filepath.Join(a.kantraDir, "task.gradle"),
 				},
 			},
 		},

--- a/cmd/analyze-bin_test.go
+++ b/cmd/analyze-bin_test.go
@@ -1,0 +1,19 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGradleSourcesTaskFileConfiguration(t *testing.T) {
+	a := analyzeCommand{}
+	a.kantraDir = "kantraDir"
+	configs, err := a.createProviderConfigsContainerless([]interface{}{})
+	if err != nil {
+		t.Fail()
+	}
+
+	assert.NotEmpty(t, configs)
+	assert.Equal(t, configs[0].InitConfig[0].ProviderSpecificConfig["gradleSourcesTaskFile"], "kantraDir/task.gradle")
+}

--- a/docs/containerless.md
+++ b/docs/containerless.md
@@ -1,8 +1,12 @@
 # Run Containerless Kantra
 
-Have OpenJDK 17+ and Maven installed
-
-Have $JAVA_HOME set.
+Requirements:
+- Have OpenJDK 17+ and Maven installed.
+- Have $JAVA_HOME set.
+- **For Gradle analysis**:
+  - Have OpenJDK 8 installed.
+  - Have $JAVA8_HOME set and pointing to the OpenJDK 8 home.
+  - The project should have a Gradle wrapper.
 
 ## Download kantra and requirements:
 


### PR DESCRIPTION
https://issues.redhat.com/browse/MTA-4033
https://issues.redhat.com/browse/MTA-3780
https://github.com/konveyor/analyzer-lsp/issues/869

Requires:
- https://github.com/konveyor/java-analyzer-bundle/pull/141
- https://github.com/konveyor/analyzer-lsp/pull/872

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Java analysis (containerless mode) now includes the Gradle task file when packaging platform artifacts.
  * CLI: documented --run-local flag for containerless Java analysis (defaults to true).

* **Documentation**
  * README updated and new containerless mode doc added with requirements, including Gradle-specific instructions.

* **Tests**
  * Added a unit test to verify Gradle task file configuration.

* **Chores**
  * Ignore root-level settings.json via .gitignore.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->