### PR TITLE
Get target dirs for Java binaries

### DIFF
--- a/cmd/analyze-bin.go
+++ b/cmd/analyze-bin.go
@@ -132,6 +132,17 @@ func (a *analyzeCommand) RunAnalysisContainerless(ctx context.Context) error {
 		os.Exit(1)
 	}
 
+	providers := map[string]provider.InternalProviderClient{}
+	providerLocations := []string{}
+
+	javaProvider, javaLocations, additionalBuiltinConfigs, err := a.setupJavaProvider(ctx, analyzeLog)
+	if err != nil {
+		errLog.Error(err, "unable to start Java provider")
+		os.Exit(1)
+	}
+	providers[util.JavaProvider] = javaProvider
+	providerLocations = append(providerLocations, javaLocations...)
+
 	//scopes := []engine.Scope{}
 	javaTargetPaths, err := kantraProvider.WalkJavaPathForTarget(a.log, a.isFileInput, a.input)
 	if err != nil {
@@ -139,15 +150,13 @@ func (a *analyzeCommand) RunAnalysisContainerless(ctx context.Context) error {
 		a.log.Error(err, "error getting target subdir in Java project - some duplicate incidents may occur")
 	}
 
-	// Get the configs
-	a.log.Info("creating provider config")
-	finalConfigs, err := a.createProviderConfigsContainerless(javaTargetPaths)
+	builtinProvider, builtinLocations, err := a.setupBuiltinProvider(ctx, javaTargetPaths, additionalBuiltinConfigs, analyzeLog)
 	if err != nil {
-		errLog.Error(err, "unable to get Java provider configuration")
+		errLog.Error(err, "unable to start builtin provider")
 		os.Exit(1)
 	}
-
-	providers, providerLocations := a.setInternalProviders(finalConfigs, analyzeLog)
+	providers["builtin"] = builtinProvider
+	providerLocations = append(providerLocations, builtinLocations...)
 
 	engineCtx, engineSpan := tracing.StartNewSpan(ctx, "rule-engine")
 	//start up the rule eng
@@ -184,11 +193,6 @@ func (a *analyzeCommand) RunAnalysisContainerless(ctx context.Context) error {
 		for k, v := range internNeedProviders {
 			needProviders[k] = v
 		}
-	}
-
-	err = a.startProvidersContainerless(ctx, needProviders)
-	if err != nil {
-		os.Exit(1)
 	}
 
 	// start dependency analysis for full analysis mode only
@@ -404,7 +408,24 @@ func (a *analyzeCommand) setBinMapContainerless() error {
 	return nil
 }
 
-func (a *analyzeCommand) createProviderConfigsContainerless(excludedTargetPaths []interface{}) ([]provider.Config, error) {
+func (a *analyzeCommand) makeBuiltinProviderConfig(excludedTargetPaths []interface{}) provider.Config {
+	builtinConfig := provider.Config{
+		Name: "builtin",
+		InitConfig: []provider.InitConfig{
+			{
+				Location:               a.input,
+				AnalysisMode:           provider.AnalysisMode(a.mode),
+				ProviderSpecificConfig: map[string]interface{}{},
+			},
+		},
+	}
+	if len(excludedTargetPaths) > 0 {
+		builtinConfig.InitConfig[0].ProviderSpecificConfig["excludedDirs"] = excludedTargetPaths
+	}
+	return builtinConfig
+}
+
+func (a *analyzeCommand) makeJavaProviderConfig() provider.Config {
 	javaConfig := provider.Config{
 		Name:       util.JavaProvider,
 		BinaryPath: a.reqMap["jdtls"],
@@ -431,20 +452,12 @@ func (a *analyzeCommand) createProviderConfigsContainerless(excludedTargetPaths 
 	if Settings.JvmMaxMem != "" {
 		javaConfig.InitConfig[0].ProviderSpecificConfig["jvmMaxMem"] = Settings.JvmMaxMem
 	}
+	return javaConfig
+}
 
-	builtinConfig := provider.Config{
-		Name: "builtin",
-		InitConfig: []provider.InitConfig{
-			{
-				Location:               a.input,
-				AnalysisMode:           provider.AnalysisMode(a.mode),
-				ProviderSpecificConfig: map[string]interface{}{},
-			},
-		},
-	}
-	if len(excludedTargetPaths) > 0 {
-		builtinConfig.InitConfig[0].ProviderSpecificConfig["excludedDirs"] = excludedTargetPaths
-	}
+func (a *analyzeCommand) createProviderConfigsContainerless(excludedTargetPaths []interface{}) ([]provider.Config, error) {
+	builtinConfig := a.makeBuiltinProviderConfig(excludedTargetPaths)
+	javaConfig := a.makeJavaProviderConfig()
 
 	provConfigs := []provider.Config{builtinConfig, javaConfig}
 
@@ -525,34 +538,131 @@ func (a *analyzeCommand) setConfigsContainerless(configs []provider.Config) []pr
 	return finalConfigs
 }
 
+func (a *analyzeCommand) setBuiltinProvider(config provider.Config, analysisLog logr.Logger) (provider.InternalProviderClient, error) {
+	a.log.Info("setting provider from provider config", "provider", config.Name)
+	config.ContextLines = a.contextLines
+
+	// IF analysis mode is set from the CLI, then we will override this for each init config
+	if a.mode != "" {
+		inits := []provider.InitConfig{}
+		for _, i := range config.InitConfig {
+			i.AnalysisMode = provider.AnalysisMode(a.mode)
+			inits = append(inits, i)
+		}
+		config.InitConfig = inits
+	}
+
+	prov, err := lib.GetProviderClient(config, analysisLog)
+	if err != nil {
+		a.log.Error(err, "failed to create builtin provider")
+		return nil, err
+	}
+
+	return prov, nil
+}
+
+func (a *analyzeCommand) setJavaProvider(config provider.Config, analysisLog logr.Logger) provider.InternalProviderClient {
+	a.log.Info("setting provider from provider config", "provider", config.Name)
+	config.ContextLines = a.contextLines
+
+	// If analysis mode is set from the CLI, then we will override this for each init config
+	if a.mode != "" {
+		inits := []provider.InitConfig{}
+		for _, i := range config.InitConfig {
+			i.AnalysisMode = provider.AnalysisMode(a.mode)
+			inits = append(inits, i)
+		}
+		config.InitConfig = inits
+	}
+
+	return java.NewJavaProvider(analysisLog, "java", a.contextLines, config)
+}
+
+func (a *analyzeCommand) setupJavaProvider(ctx context.Context, analysisLog logr.Logger) (provider.InternalProviderClient, []string, []provider.InitConfig, error) {
+	javaConfig := a.makeJavaProviderConfig()
+	if a.httpProxy != "" || a.httpsProxy != "" {
+		proxy := provider.Proxy{
+			HTTPProxy:  a.httpProxy,
+			HTTPSProxy: a.httpsProxy,
+			NoProxy:    a.noProxy,
+		}
+		javaConfig.Proxy = &proxy
+	}
+	javaConfig.ContextLines = a.contextLines
+
+	providerLocations := []string{}
+	for _, ind := range javaConfig.InitConfig {
+		providerLocations = append(providerLocations, ind.Location)
+	}
+
+	javaProvider := a.setJavaProvider(javaConfig, analysisLog)
+
+	a.log.Info("starting provider", "provider", util.JavaProvider)
+	initCtx, initSpan := tracing.StartNewSpan(ctx, "init",
+		attribute.Key("provider").String(util.JavaProvider))
+	additionalBuiltinConfs, err := javaProvider.ProviderInit(initCtx, nil)
+	if err != nil {
+		a.log.Error(err, "unable to init the providers", "provider", util.JavaProvider)
+		initSpan.End()
+		return nil, nil, nil, err
+	}
+	initSpan.End()
+
+	return javaProvider, providerLocations, additionalBuiltinConfs, nil
+}
+
+func (a *analyzeCommand) setupBuiltinProvider(ctx context.Context, excludedTargetPaths []interface{}, additionalConfigs []provider.InitConfig, analysisLog logr.Logger) (provider.InternalProviderClient, []string, error) {
+	a.log.Info("setting up builtin provider")
+	builtinConfig := a.makeBuiltinProviderConfig(excludedTargetPaths)
+
+	// Set proxy if configured
+	if a.httpProxy != "" || a.httpsProxy != "" {
+		proxy := provider.Proxy{
+			HTTPProxy:  a.httpProxy,
+			HTTPSProxy: a.httpsProxy,
+			NoProxy:    a.noProxy,
+		}
+		builtinConfig.Proxy = &proxy
+	}
+	builtinConfig.ContextLines = a.contextLines
+
+	providerLocations := []string{}
+	for _, ind := range builtinConfig.InitConfig {
+		providerLocations = append(providerLocations, ind.Location)
+	}
+
+	builtinProvider, err := a.setBuiltinProvider(builtinConfig, analysisLog)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	a.log.Info("starting provider", "provider", "builtin")
+	if _, err := builtinProvider.ProviderInit(ctx, additionalConfigs); err != nil {
+		a.log.Error(err, "unable to init the builtin provider")
+		return nil, nil, err
+	}
+
+	return builtinProvider, providerLocations, nil
+}
+
 func (a *analyzeCommand) setInternalProviders(finalConfigs []provider.Config, analysisLog logr.Logger) (map[string]provider.InternalProviderClient, []string) {
 	providers := map[string]provider.InternalProviderClient{}
 	providerLocations := []string{}
+
 	for _, config := range finalConfigs {
-		a.log.Info("setting provider from provider config", "provider", config.Name)
-		config.ContextLines = a.contextLines
 		for _, ind := range config.InitConfig {
 			providerLocations = append(providerLocations, ind.Location)
 		}
-		// IF analsyis mode is set from the CLI, then we will override this for each init config
-		if a.mode != "" {
-			inits := []provider.InitConfig{}
-			for _, i := range config.InitConfig {
-				i.AnalysisMode = provider.AnalysisMode(a.mode)
-				inits = append(inits, i)
-			}
-			config.InitConfig = inits
-		}
+
 		var prov provider.InternalProviderClient
 		var err error
+
 		// only create java and builtin providers
 		if config.Name == util.JavaProvider {
-			prov = java.NewJavaProvider(analysisLog, "java", a.contextLines, config)
-
+			prov = a.setJavaProvider(config, analysisLog)
 		} else if config.Name == "builtin" {
-			prov, err = lib.GetProviderClient(config, analysisLog)
+			prov, err = a.setBuiltinProvider(config, analysisLog)
 			if err != nil {
-				a.log.Error(err, "failed to create builtin provider")
 				os.Exit(1)
 			}
 		}

--- a/cmd/analyze-bin_test.go
+++ b/cmd/analyze-bin_test.go
@@ -1,14 +1,22 @@
 package cmd
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
+	"github.com/go-logr/logr"
+	kantraProvider "github.com/konveyor-ecosystem/kantra/pkg/provider"
+	"github.com/konveyor/analyzer-lsp/provider"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+// Use logr.Discard() for testing - it's the standard no-op logger
 
 func TestGradleSourcesTaskFileConfiguration(t *testing.T) {
 	a := analyzeCommand{}
-	a.kantraDir = "kantraDir"
+	a.AnalyzeCommandContext.kantraDir = "kantraDir"
 	configs, err := a.createProviderConfigsContainerless([]interface{}{})
 	if err != nil {
 		t.Fail()
@@ -16,4 +24,358 @@ func TestGradleSourcesTaskFileConfiguration(t *testing.T) {
 
 	assert.NotEmpty(t, configs)
 	assert.Equal(t, configs[0].InitConfig[0].ProviderSpecificConfig["gradleSourcesTaskFile"], "kantraDir/task.gradle")
+}
+
+func TestMakeBuiltinProviderConfig(t *testing.T) {
+	tests := []struct {
+		name                string
+		input               string
+		mode                string
+		excludedTargetPaths []interface{}
+		expectedName        string
+		expectedLocation    string
+		expectedMode        provider.AnalysisMode
+		expectExcludedDirs  bool
+	}{
+		{
+			name:                "basic builtin config",
+			input:               "/test/input",
+			mode:                "full",
+			excludedTargetPaths: nil,
+			expectedName:        "builtin",
+			expectedLocation:    "/test/input",
+			expectedMode:        provider.AnalysisMode("full"),
+			expectExcludedDirs:  false,
+		},
+		{
+			name:                "builtin config with excluded paths",
+			input:               "/test/input",
+			mode:                "source-only",
+			excludedTargetPaths: []interface{}{"target", "build"},
+			expectedName:        "builtin",
+			expectedLocation:    "/test/input",
+			expectedMode:        provider.AnalysisMode("source-only"),
+			expectExcludedDirs:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := analyzeCommand{
+				input: tt.input,
+				mode:  tt.mode,
+			}
+
+			config := a.makeBuiltinProviderConfig(tt.excludedTargetPaths)
+
+			assert.Equal(t, tt.expectedName, config.Name)
+			require.Len(t, config.InitConfig, 1)
+			assert.Equal(t, tt.expectedLocation, config.InitConfig[0].Location)
+			assert.Equal(t, tt.expectedMode, config.InitConfig[0].AnalysisMode)
+
+			if tt.expectExcludedDirs {
+				excludedDirs, exists := config.InitConfig[0].ProviderSpecificConfig["excludedDirs"]
+				assert.True(t, exists)
+				assert.Equal(t, tt.excludedTargetPaths, excludedDirs)
+			} else {
+				_, exists := config.InitConfig[0].ProviderSpecificConfig["excludedDirs"]
+				assert.False(t, exists)
+			}
+		})
+	}
+}
+
+func TestMakeJavaProviderConfig(t *testing.T) {
+	tests := []struct {
+		name               string
+		input              string
+		mode               string
+		kantraDir          string
+		mavenSettingsFile  string
+		jvmMaxMem          string
+		disableMavenSearch bool
+		reqMap             map[string]string
+	}{
+		{
+			name:      "basic java config",
+			input:     "/test/input",
+			mode:      "full",
+			kantraDir: "/test/kantra",
+			reqMap: map[string]string{
+				"jdtls":  "/test/jdtls",
+				"bundle": "/test/bundle",
+			},
+		},
+		{
+			name:               "java config with maven settings",
+			input:              "/test/input",
+			mode:               "source-only",
+			kantraDir:          "/test/kantra",
+			mavenSettingsFile:  "/test/settings.xml",
+			jvmMaxMem:          "4g",
+			disableMavenSearch: true,
+			reqMap: map[string]string{
+				"jdtls":  "/test/jdtls",
+				"bundle": "/test/bundle",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.jvmMaxMem != "" {
+				Settings.JvmMaxMem = tt.jvmMaxMem
+				defer func() { Settings.JvmMaxMem = "" }() // cleanup
+			}
+
+			a := analyzeCommand{
+				input:              tt.input,
+				mode:               tt.mode,
+				mavenSettingsFile:  tt.mavenSettingsFile,
+				disableMavenSearch: tt.disableMavenSearch,
+			}
+			a.AnalyzeCommandContext.kantraDir = tt.kantraDir
+			a.AnalyzeCommandContext.reqMap = tt.reqMap
+
+			config := a.makeJavaProviderConfig()
+
+			assert.Equal(t, "java", config.Name)
+			assert.Equal(t, tt.reqMap["jdtls"], config.BinaryPath)
+			require.Len(t, config.InitConfig, 1)
+
+			initConfig := config.InitConfig[0]
+			assert.Equal(t, tt.input, initConfig.Location)
+			assert.Equal(t, provider.AnalysisMode(tt.mode), initConfig.AnalysisMode)
+
+			psc := initConfig.ProviderSpecificConfig
+			assert.Equal(t, true, psc["cleanExplodedBin"])
+			assert.Equal(t, "/test/kantra/fernflower.jar", psc["fernFlowerPath"])
+			assert.Equal(t, "java", psc["lspServerName"])
+			assert.Equal(t, tt.reqMap["bundle"], psc["bundles"])
+			assert.Equal(t, tt.reqMap["jdtls"], psc["lspServerPath"])
+			assert.Equal(t, "/test/kantra/maven.default.index", psc["depOpenSourceLabelsFile"])
+			assert.Equal(t, tt.disableMavenSearch, psc["disableMavenSearch"])
+			assert.Equal(t, "/test/kantra/task.gradle", psc["gradleSourcesTaskFile"])
+
+			if tt.mavenSettingsFile != "" {
+				assert.Equal(t, tt.mavenSettingsFile, psc["mavenSettingsFile"])
+			} else {
+				_, exists := psc["mavenSettingsFile"]
+				assert.False(t, exists)
+			}
+
+			if tt.jvmMaxMem != "" {
+				assert.Equal(t, tt.jvmMaxMem, psc["jvmMaxMem"])
+			} else {
+				_, exists := psc["jvmMaxMem"]
+				assert.False(t, exists)
+			}
+		})
+	}
+}
+
+func TestWalkJavaPathForTarget(t *testing.T) {
+	// Create a temporary directory for testing
+	tempDir, err := os.MkdirTemp("", "walk-java-test-")
+	require.NoError(t, err)
+	defer os.RemoveAll(tempDir)
+
+	tests := []struct {
+		name          string
+		isFileInput   bool
+		setupDirs     []string
+		setupFiles    []string
+		expectedPaths []string
+		expectError   bool
+		errorContains string
+	}{
+		{
+			name:          "directory with no target folders",
+			isFileInput:   false,
+			setupDirs:     []string{"src/main/java", "src/test/java"},
+			setupFiles:    []string{"pom.xml", "src/main/java/App.java"},
+			expectedPaths: []string{},
+			expectError:   false,
+		},
+		{
+			name:          "directory with single target folder",
+			isFileInput:   false,
+			setupDirs:     []string{"src/main/java", "target", "target/classes"},
+			setupFiles:    []string{"pom.xml", "src/main/java/App.java"},
+			expectedPaths: []string{"target"},
+			expectError:   false,
+		},
+		{
+			name:        "directory with multiple target folders",
+			isFileInput: false,
+			setupDirs: []string{
+				"module1/src/main/java", "module1/target", "module1/target/classes",
+				"module2/src/main/java", "module2/target", "module2/target/classes",
+				"nested/module3/target",
+			},
+			setupFiles: []string{
+				"pom.xml", "module1/pom.xml", "module2/pom.xml",
+				"module1/src/main/java/App1.java", "module2/src/main/java/App2.java",
+			},
+			expectedPaths: []string{"module1/target", "module2/target", "nested/module3/target"},
+			expectError:   false,
+		},
+		{
+			name:        "nested target folders",
+			isFileInput: false,
+			setupDirs: []string{
+				"parent/target", "parent/target/classes",
+				"parent/child/target", "parent/child/target/classes",
+			},
+			setupFiles:    []string{"parent/pom.xml", "parent/child/pom.xml"},
+			expectedPaths: []string{"parent/target", "parent/child/target"},
+			expectError:   false,
+		},
+		{
+			name:          "target as file not directory",
+			isFileInput:   false,
+			setupDirs:     []string{"src/main/java"},
+			setupFiles:    []string{"pom.xml", "target", "src/main/java/App.java"},
+			expectedPaths: []string{},
+			expectError:   false,
+		},
+		{
+			name:          "empty directory",
+			isFileInput:   false,
+			setupDirs:     []string{},
+			setupFiles:    []string{},
+			expectedPaths: []string{},
+			expectError:   false,
+		},
+		{
+			name:          "non-existent directory",
+			isFileInput:   false,
+			setupDirs:     []string{},
+			setupFiles:    []string{},
+			expectedPaths: nil,
+			expectError:   true,
+			errorContains: "no such file or directory",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testDir := filepath.Join(tempDir, tt.name)
+			err := os.MkdirAll(testDir, 0755)
+			require.NoError(t, err)
+
+			for _, dir := range tt.setupDirs {
+				err := os.MkdirAll(filepath.Join(testDir, dir), 0755)
+				require.NoError(t, err)
+			}
+
+			for _, file := range tt.setupFiles {
+				filePath := filepath.Join(testDir, file)
+				err := os.MkdirAll(filepath.Dir(filePath), 0755)
+				require.NoError(t, err)
+				f, err := os.Create(filePath)
+				require.NoError(t, err)
+				f.Close()
+			}
+
+			inputPath := testDir
+			if tt.expectError && tt.errorContains == "no such file or directory" {
+				inputPath = filepath.Join(testDir, "non-existent")
+			}
+
+			result, err := kantraProvider.WalkJavaPathForTarget(logr.Discard(), tt.isFileInput, inputPath)
+
+			if tt.expectError {
+				require.Error(t, err)
+				if tt.errorContains != "" {
+					assert.Contains(t, err.Error(), tt.errorContains)
+				}
+				return
+			}
+
+			require.NoError(t, err)
+
+			var resultPaths []string
+			for _, path := range result {
+				relPath, err := filepath.Rel(testDir, path.(string))
+				require.NoError(t, err)
+				resultPaths = append(resultPaths, relPath)
+			}
+
+			assert.ElementsMatch(t, tt.expectedPaths, resultPaths)
+		})
+	}
+}
+
+func TestWalkJavaPathForTargetFileInput(t *testing.T) {
+	t.Run("file input with non-existent file", func(t *testing.T) {
+		nonExistentFile := "/path/to/non/existent/file.jar"
+
+		result, err := kantraProvider.WalkJavaPathForTarget(logr.Discard(), true, nonExistentFile)
+
+		// Should return an error since the file doesn't exist
+		assert.Error(t, err)
+		assert.Nil(t, result)
+	})
+}
+
+func TestWalkJavaPathForTargetIntegration(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "java-project-integration-")
+	require.NoError(t, err)
+	defer os.RemoveAll(tempDir)
+
+	// Create a realistic Maven multi-module project structure
+	projectStructure := map[string][]string{
+		"dirs": {
+			"parent-project",
+			"parent-project/module-a/src/main/java/com/example",
+			"parent-project/module-a/src/test/java/com/example",
+			"parent-project/module-a/target/classes/com/example",
+			"parent-project/module-a/target/test-classes",
+			"parent-project/module-b/src/main/java/com/example",
+			"parent-project/module-b/target/classes",
+			"parent-project/target/site",
+		},
+		"files": {
+			"parent-project/pom.xml",
+			"parent-project/module-a/pom.xml",
+			"parent-project/module-a/src/main/java/com/example/AppA.java",
+			"parent-project/module-a/src/test/java/com/example/AppATest.java",
+			"parent-project/module-b/pom.xml",
+			"parent-project/module-b/src/main/java/com/example/AppB.java",
+		},
+	}
+
+	for _, dir := range projectStructure["dirs"] {
+		err := os.MkdirAll(filepath.Join(tempDir, dir), 0755)
+		require.NoError(t, err)
+	}
+
+	for _, file := range projectStructure["files"] {
+		filePath := filepath.Join(tempDir, file)
+		f, err := os.Create(filePath)
+		require.NoError(t, err)
+		f.Close()
+	}
+
+	projectRoot := filepath.Join(tempDir, "parent-project")
+	result, err := kantraProvider.WalkJavaPathForTarget(logr.Discard(), false, projectRoot)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	var relativePaths []string
+	for _, path := range result {
+		relPath, err := filepath.Rel(projectRoot, path.(string))
+		require.NoError(t, err)
+		relativePaths = append(relativePaths, relPath)
+	}
+
+	expectedPaths := []string{
+		"module-a/target",
+		"module-b/target",
+		"target",
+	}
+
+	assert.ElementsMatch(t, expectedPaths, relativePaths)
 }

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/onsi/gomega v1.38.0
 	github.com/phayes/freeport v0.0.0-20220201140144-74d24b5ae9f5
 	github.com/spf13/cobra v1.8.1
+	github.com/stretchr/testify v1.10.0
 	go.lsp.dev/uri v0.3.0
 	go.opentelemetry.io/otel v1.34.0
 	go.opentelemetry.io/otel/trace v1.34.0
@@ -80,7 +81,6 @@ require (
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06 // indirect
 	github.com/spf13/cast v1.7.0 // indirect
-	github.com/stretchr/testify v1.10.0 // indirect
 	github.com/swaggest/jsonschema-go v0.3.70 // indirect
 	github.com/swaggest/openapi-go v0.2.50 // indirect
 	github.com/swaggest/refl v1.3.0 // indirect

--- a/pkg/provider/java.go
+++ b/pkg/provider/java.go
@@ -126,7 +126,12 @@ func WaitForTargetDir(log logr.Logger, path string) error {
 	if err != nil {
 		return err
 	}
-	log.V(7).Info("waiting for target directory in decompiled Java project")
+
+	// target dir already exists
+	if _, err := os.Stat(filepath.Join(path, "target")); err == nil {
+		return nil
+	}
+	log.Info("waiting for target directory in decompiled Java project")
 
 	for {
 		select {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Streamlined analysis provider initialization for faster, more reliable startup.
- Bug Fixes
  - Honors HTTP/HTTPS proxy settings during provider setup.
  - Avoids unnecessary waiting when target directories already exist.
  - Clearer, more actionable error messages during initialization.
- Tests
  - Added comprehensive tests for provider config generation and Java target path discovery, including edge cases and integration-style scenarios.
- Chores
  - Promoted testing library to a direct dependency for improved test stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->