### PR TITLE
:bug: Do not use standard ruleset when running tests locally

### DIFF
--- a/pkg/testing/runner.go
+++ b/pkg/testing/runner.go
@@ -322,6 +322,7 @@ func runLocal(logFile io.Writer, dir string, analysisParams AnalysisParams, inpu
 		"--output", filepath.Join(dir, "output"),
 		"--rules", filepath.Join(dir, "rules.yaml"),
 		"--overwrite",
+		"--enable-default-rulesets=false",
 	}
 	if analysisParams.DepLabelSelector != "" {
 		args = append(args, []string{

--- a/pkg/testing/runner_test.go
+++ b/pkg/testing/runner_test.go
@@ -7,7 +7,6 @@ import (
 
 // ENV_RUN_LOCAL enables the runner to run analysis locally instead of a container
 // this must be set in CI containers to make sure we are not launching containers
-const ENV_RUN_LOCAL = "RUN_LOCAL"
 const RUNNER_IMG = "RUNNER_IMG"
 
 func Test_defaultRunner_Run(t *testing.T) {
@@ -16,12 +15,21 @@ func Test_defaultRunner_Run(t *testing.T) {
 		testFiles  []string
 		wantErr    bool
 		wantResult []Result
+		runLocal   bool
 	}{
 		{
 			name: "simple test",
 			testFiles: []string{
 				"./examples/ruleset/discovery.test.yaml",
 			},
+			runLocal: false,
+		},
+		{
+			name: "run local test",
+			testFiles: []string{
+				"./examples/ruleset/discovery.test.yaml",
+			},
+			runLocal: true,
 		},
 	}
 	for _, tt := range tests {
@@ -30,10 +38,9 @@ func Test_defaultRunner_Run(t *testing.T) {
 			if err != nil {
 				t.Errorf("failed setting up test")
 			}
-			_, runLocal := os.LookupEnv(ENV_RUN_LOCAL)
 			r := NewRunner()
 			_, err = r.Run(testFiles, TestOptions{
-				RunLocal:       runLocal,
+				RunLocal:       tt.runLocal,
 				ContainerImage: os.Getenv(RUNNER_IMG),
 			})
 			if (err == nil) != tt.wantErr {


### PR DESCRIPTION
https://issues.redhat.com/browse/MTA-6008

Fixes https://github.com/konveyor/kantra/issues/525

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Local test execution now disables default rulesets by default, so only explicitly configured rules apply.
  * Tests now specify local vs non-local runs per case instead of relying on external environment configuration.
  * Adds an explicit local-run test case to ensure coverage.
  * Improves determinism and reduces unexpected rule triggers; no changes to runtime behavior or error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->