### PR TITLE
Namespace discovery manifest output to match hub

### DIFF
--- a/cmd/asset_generation/discover/cloud_foundry/cmd.go
+++ b/cmd/asset_generation/discover/cloud_foundry/cmd.go
@@ -31,6 +31,10 @@ var (
 	listApps             bool
 )
 
+type manifestOutput struct {
+	Manifest cfProvider.Application `yaml:"manifest"`
+}
+
 func NewDiscoverCloudFoundryCommand(log logr.Logger) (string, *cobra.Command) {
 	logger = log
 	cmd := &cobra.Command{
@@ -327,8 +331,13 @@ func OutputAppManifestsYAML(out io.Writer, discoverResult *providerTypes.Discove
 	}
 	printer := printers.NewOutput(out)
 	printFunc := printer.ToStdout
+
+	output := map[string]any{
+		"manifest": discoverResult.Content,
+	}
+
 	// Marshal content
-	d, err := marshalUnmarshal[cfProvider.Application](discoverResult.Content)
+	d, err := marshalUnmarshal[manifestOutput](output)
 	if err != nil {
 		return err
 	}

--- a/cmd/asset_generation/discover/cloud_foundry/cmd_test.go
+++ b/cmd/asset_generation/discover/cloud_foundry/cmd_test.go
@@ -880,8 +880,8 @@ env:
 services:
   - database-service
 docker:
-    image: myregistry/myapp:latest
-    username: docker-registry-user
+  image: myregistry/myapp:latest
+  username: docker-registry-user
 `)
 	manifestPath := filepath.Join(tempDir, "manifest-with-secrets.yml")
 	Expect(os.WriteFile(manifestPath, manifestContent, 0644)).To(Succeed())
@@ -902,22 +902,23 @@ func readOutputFile(outputPath, filename string) string {
 }
 
 func getExpectedYAMLOutput() string {
-	return `name: test-app
-processes:
-    - type: web
-      memory: 256M
-      healthCheck:
-        endpoint: ""
-        invocationTimeout: 1
-        interval: 30
-        type: port
-        timeout: 60
-      readinessCheck:
-        endpoint: ""
-        invocationTimeout: 0
-        interval: 0
-        type: process
-      instances: 1`
+	return `manifest:
+    name: test-app
+    processes:
+        - type: web
+          memory: 256M
+          healthCheck:
+            endpoint: ""
+            invocationTimeout: 1
+            interval: 30
+            type: port
+            timeout: 60
+          readinessCheck:
+            endpoint: ""
+            invocationTimeout: 0
+            interval: 0
+            type: process
+          instances: 1`
 }
 
 func helperCreateTestManifest(manifestPath string, content string, perm os.FileMode) error {


### PR DESCRIPTION
This puts all key/values for CF discovery manifest output to start with:
```
manifest:
  ...
```