### PR TITLE
Set proxy option for containers

### DIFF
--- a/cmd/analyze.go
+++ b/cmd/analyze.go
@@ -1198,6 +1198,19 @@ func (a *analyzeCommand) RunAnalysis(ctx context.Context, volName string) error 
 		}
 	}
 
+	// Pass proxy settings from command line flags to container
+	proxyFlags := map[string]string{
+		"HTTP_PROXY":  a.httpProxy,
+		"HTTPS_PROXY": a.httpsProxy,
+		"NO_PROXY":    a.noProxy,
+	}
+
+	for envVar, value := range proxyFlags {
+		if value != "" {
+			containerOpts = append(containerOpts, container.WithEnv(envVar, value))
+		}
+	}
+
 	// TODO (pgaikwad): run analysis & deps in parallel
 	err = c.Run(ctx, containerOpts...)
 	if err != nil {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Analyzer now respects proxy settings provided via CLI flags. You can pass HTTP_PROXY, HTTPS_PROXY, and NO_PROXY to ensure analysis runs correctly behind corporate or custom proxies.
  - Proxy values from CLI flags are applied directly to the analysis container’s environment, complementing existing support for host environment variables.
  - Improves reliability and connectivity for analysis tasks in proxied networks without requiring global environment configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->