### PR TITLE
Update Java provider for gradle cmd fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -133,7 +133,7 @@ require (
 	github.com/codingconcepts/env v0.0.0-20200821220118-a8fbf8d84482
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/konveyor/analyzer-lsp v0.7.0-alpha.2.0.20250625194402-05dca9b4ac43
-	github.com/konveyor/analyzer-lsp/external-providers/java-external-provider v0.0.0-20250827181032-bb3c88795056
+	github.com/konveyor/analyzer-lsp/external-providers/java-external-provider v0.0.0-20250929170248-b2a4ce23b6e5
 	github.com/shopspring/decimal v1.4.0 // indirect
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/pflag v1.0.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -140,6 +140,8 @@ github.com/konveyor/analyzer-lsp v0.7.0-alpha.2.0.20250625194402-05dca9b4ac43 h1
 github.com/konveyor/analyzer-lsp v0.7.0-alpha.2.0.20250625194402-05dca9b4ac43/go.mod h1:/7nwwqN27iODJy/PBai9W16KH91LrPGx1nwu21+rCOg=
 github.com/konveyor/analyzer-lsp/external-providers/java-external-provider v0.0.0-20250827181032-bb3c88795056 h1:y1Kgz2ZFp9NUH4rQOV0ecgqyg2kmb8ZdHyxnAUmqtbE=
 github.com/konveyor/analyzer-lsp/external-providers/java-external-provider v0.0.0-20250827181032-bb3c88795056/go.mod h1:nqWGtKrCB+oFbw/VFfAnxFrrFZuZSaJ/K5rq8D0sFhg=
+github.com/konveyor/analyzer-lsp/external-providers/java-external-provider v0.0.0-20250929170248-b2a4ce23b6e5 h1:B/CTogikgNYMvkZnMSo3WXp6lFKpCP35x+2NUenFLSY=
+github.com/konveyor/analyzer-lsp/external-providers/java-external-provider v0.0.0-20250929170248-b2a4ce23b6e5/go.mod h1:nqWGtKrCB+oFbw/VFfAnxFrrFZuZSaJ/K5rq8D0sFhg=
 github.com/konveyor/asset-generation v0.1.12 h1:G3ZUzCzC+Shl0WqhZ8s/1rt26z2jEbZM9q2WmUGyjF0=
 github.com/konveyor/asset-generation v0.1.12/go.mod h1:DYew3e2TaiI0OB05HThjlD/YcO8rZTa+o8JmNPY4uQI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated an underlying Java analysis provider dependency to the latest patch release to keep the app aligned with upstream improvements.
  * This maintenance update is aimed at stability and compatibility; no user-facing features or behavior changes are expected.
  * No configuration changes or actions are required from users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->