### PR TITLE
:sparkles: Update containerless.md to use different PATH

### DIFF
--- a/docs/containerless.md
+++ b/docs/containerless.md
@@ -15,7 +15,7 @@ Download appropriate zip for your OS [here](https://github.com/konveyor/kantra/r
 ## Move kantra binary to your $PATH:
 
 ```sh
-mv $HOME/kantra.<os>.<arch>/<os>-kantra /usr/bin
+mv $HOME/kantra.<os>.<arch>/<os>-kantra /usr/local/bin
 ```
 
 ### Move requirements to kantra known location, or run kantra from the current directory:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated installation instructions in the containerless guide to move the kantra binary to /usr/local/bin instead of /usr/bin.
  - Improves compatibility with standard system paths and reduces the need for elevated privileges during installation.
  - Clarifies the mv command to reflect the new destination path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->