### PR TITLE
MTA-6399: Fix VCAP_SERVICES array parsing in CF discovery

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/fsnotify/fsnotify v1.9.0
 	github.com/getkin/kin-openapi v0.108.0
 	github.com/go-logr/logr v1.4.3
-	github.com/konveyor/asset-generation v0.2.1
+	github.com/konveyor/asset-generation v0.2.2
 	github.com/onsi/ginkgo/v2 v2.25.3
 	github.com/onsi/gomega v1.38.2
 	github.com/phayes/freeport v0.0.0-20220201140144-74d24b5ae9f5

--- a/go.sum
+++ b/go.sum
@@ -144,8 +144,8 @@ github.com/konveyor/analyzer-lsp v0.8.1-alpha.2.0.20251031191139-321209b0bb21 h1
 github.com/konveyor/analyzer-lsp v0.8.1-alpha.2.0.20251031191139-321209b0bb21/go.mod h1:tZkfGRokJZqtmNVeEPIFlxltZhZXXMM5g2NNdxmhTXM=
 github.com/konveyor/analyzer-lsp/external-providers/java-external-provider v0.0.0-20251031191139-321209b0bb21 h1:UAvonakPIqBT0q3Es1Un9rngf8d6HdtcYABDXCETWsU=
 github.com/konveyor/analyzer-lsp/external-providers/java-external-provider v0.0.0-20251031191139-321209b0bb21/go.mod h1:QheVeScOOoCMuWMEYO9ypHgoasRaYddedh9cxWJwn94=
-github.com/konveyor/asset-generation v0.2.1 h1:9eiRYwseeiIw0b+FUNOW2QWxNGZi+tx6YMekOuFAiKE=
-github.com/konveyor/asset-generation v0.2.1/go.mod h1:X5K2VuEV+PEBAI5O+9mNVDtCW4vFWDvFYRThpea+56U=
+github.com/konveyor/asset-generation v0.2.2 h1:bzg4wDO3M4NxayS3b7SKk0f6Ai2MP/mioCZozhphKfw=
+github.com/konveyor/asset-generation v0.2.2/go.mod h1:X5K2VuEV+PEBAI5O+9mNVDtCW4vFWDvFYRThpea+56U=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=


### PR DESCRIPTION
Bump asset-generation lib to v0.2.2

Fixes: [MTA-6399](https://issues.redhat.com/browse/MTA-6399)

Signed-off-by: Gloria Ciavarrini <gciavarrini@redhat.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal dependencies for maintenance purposes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->