### PR TITLE
Remove maven-index.idx from release artifacts

### DIFF
--- a/.github/workflows/release-artifacts.yaml
+++ b/.github/workflows/release-artifacts.yaml
@@ -53,7 +53,6 @@ jobs:
         podman cp kantra-download:/usr/local/etc/task.gradle . && zip -r kantra.linux.${{ matrix.arch }}.zip task.gradle
         podman cp kantra-download:/usr/local/etc/task-v9.gradle . && zip -r kantra.linux.${{ matrix.arch }}.zip task-v9.gradle
         podman cp kantra-download:/usr/local/etc/maven-index.txt . && zip -r kantra.linux.${{ matrix.arch }}.zip maven-index.txt
-        podman cp kantra-download:/usr/local/etc/maven-index.idx . && zip -r kantra.linux.${{ matrix.arch }}.zip maven-index.idx
               
         podman cp kantra-download:/jdtls . && zip -r kantra.darwin.${{ matrix.arch }}.zip jdtls
         podman cp kantra-download:/bin/fernflower.jar . && zip kantra.darwin.${{ matrix.arch }}.zip fernflower.jar
@@ -63,7 +62,6 @@ jobs:
         podman cp kantra-download:/usr/local/etc/task.gradle . && zip -r kantra.darwin.${{ matrix.arch }}.zip task.gradle
         podman cp kantra-download:/usr/local/etc/task-v9.gradle . && zip -r kantra.darwin.${{ matrix.arch }}.zip task-v9.gradle
         podman cp kantra-download:/usr/local/etc/maven-index.txt . && zip -r kantra.darwin.${{ matrix.arch }}.zip maven-index.txt
-        podman cp kantra-download:/usr/local/etc/maven-index.idx . && zip -r kantra.darwin.${{ matrix.arch }}.zip maven-index.idx
 
         podman cp kantra-download:/jdtls . && zip -r kantra.windows.${{ matrix.arch }}.zip jdtls
         podman cp kantra-download:/bin/fernflower.jar . && zip kantra.windows.${{ matrix.arch }}.zip fernflower.jar
@@ -73,7 +71,6 @@ jobs:
         podman cp kantra-download:/usr/local/etc/task.gradle . && zip -r kantra.windows.${{ matrix.arch }}.zip task.gradle
         podman cp kantra-download:/usr/local/etc/task-v9.gradle . && zip -r kantra.windows.${{ matrix.arch }}.zip task-v9.gradle
         podman cp kantra-download:/usr/local/etc/maven-index.txt . && zip -r kantra.windows.${{ matrix.arch }}.zip maven-index.txt
-        podman cp kantra-download:/usr/local/etc/maven-index.idx . && zip -r kantra.windows.${{ matrix.arch }}.zip maven-index.idx
 
     - name: Upload linux binary
       uses: actions/upload-release-asset@v1


### PR DESCRIPTION
Removed maven-index.idx from artifact packaging for Linux, Darwin, and Windows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed maven-index.idx from release packages across all platforms (Linux, macOS, Windows).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->