### PR TITLE
fix: apply --override-provider-settings to builtin provider

### DIFF
--- a/cmd/analyze-hybrid.go
+++ b/cmd/analyze-hybrid.go
@@ -389,7 +389,7 @@ func (a *analyzeCommand) runParallelStartupTasks(ctx context.Context, containerL
 
 // setupBuiltinProviderHybrid creates a builtin provider for hybrid mode.
 // This is the same as containerless mode since builtin always runs in-process.
-func (a *analyzeCommand) setupBuiltinProviderHybrid(ctx context.Context, additionalConfigs []provider.InitConfig, analysisLog logr.Logger) (provider.InternalProviderClient, []string, error) {
+func (a *analyzeCommand) setupBuiltinProviderHybrid(ctx context.Context, additionalConfigs []provider.InitConfig, analysisLog logr.Logger, overrideConfigs []provider.Config) (provider.InternalProviderClient, []string, error) {
 	a.log.V(1).Info("setting up builtin provider for hybrid mode")
 
 	builtinConfig := provider.Config{
@@ -416,6 +416,9 @@ func (a *analyzeCommand) setupBuiltinProviderHybrid(ctx context.Context, additio
 		builtinConfig.Proxy = &proxy
 	}
 	builtinConfig.ContextLines = a.contextLines
+
+	// Apply override settings (same as containerized providers)
+	builtinConfig = applyProviderOverrides(builtinConfig, overrideConfigs)
 
 	providerLocations := []string{}
 	for _, ind := range builtinConfig.InitConfig {
@@ -692,7 +695,7 @@ func (a *analyzeCommand) RunAnalysisHybridInProcess(ctx context.Context) error {
 	}
 
 	// Setup builtin provider (always in-process)
-	builtinProvider, builtinLocations, err := a.setupBuiltinProviderHybrid(ctx, transformedConfigs, analyzeLog)
+	builtinProvider, builtinLocations, err := a.setupBuiltinProviderHybrid(ctx, transformedConfigs, analyzeLog, overrideConfigs)
 	if err != nil {
 		errLog.Error(err, "unable to start builtin provider")
 		return fmt.Errorf("unable to start builtin provider: %w", err)

--- a/cmd/analyze_hybrid_inprocess_test.go
+++ b/cmd/analyze_hybrid_inprocess_test.go
@@ -45,7 +45,7 @@ func Test_analyzeCommand_setupBuiltinProviderHybrid(t *testing.T) {
 
 	ctx := context.Background()
 
-	builtinProvider, locations, err := a.setupBuiltinProviderHybrid(ctx, nil, logr.Discard())
+	builtinProvider, locations, err := a.setupBuiltinProviderHybrid(ctx, nil, logr.Discard(), nil)
 
 	if err != nil {
 		t.Fatalf("setupBuiltinProviderHybrid() error = %v", err)
@@ -79,7 +79,7 @@ func Test_analyzeCommand_setupBuiltinProviderHybrid_WithProxy(t *testing.T) {
 
 	ctx := context.Background()
 
-	builtinProvider, _, err := a.setupBuiltinProviderHybrid(ctx, nil, logr.Discard())
+	builtinProvider, _, err := a.setupBuiltinProviderHybrid(ctx, nil, logr.Discard(), nil)
 
 	if err != nil {
 		t.Fatalf("setupBuiltinProviderHybrid() error = %v", err)


### PR DESCRIPTION
## Summary
- Fixes the builtin provider to respect `--override-provider-settings` flag in both containerless and hybrid modes
- Loads override provider settings and applies them to the builtin provider configuration, consistent with how containerized providers are handled
- Updates function signatures for `setupBuiltinProvider` and `setupBuiltinProviderHybrid` to accept override configs
- Updates unit tests to pass the new parameter

## Test plan
- Verify that `--override-provider-settings` flag now affects the builtin provider's behavior
- Ensure existing unit tests pass with updated function signatures
- Test in both containerless and hybrid modes to confirm override settings are applied

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Provider override functionality is now available in containerless and hybrid analysis modes, matching containerized analysis.
  * Users can customize provider settings (context lines, proxy, analysis parameters) consistently across all analysis modes.
  * Unified override support improves configuration flexibility and ensures consistent behavior regardless of analysis mode.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->