### PR TITLE
Fixes for go and nodejs test cmd, provider logs, and maven index path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,7 +69,8 @@ RUN echo -e "[almalinux9-appstream]" \
  "\nenabled = 1" \
  "\ngpgcheck = 0" > /etc/yum.repos.d/almalinux.repo
 
-RUN microdnf -y install podman
+RUN microdnf -y install podman nodejs
+RUN npm install -g typescript-language-server typescript
 RUN echo mta:x:1001:0:1001 user:/home/mta:/sbin/nologin > /etc/passwd
 RUN echo mta:10000:5000 > /etc/subuid
 RUN echo mta:10000:5000 > /etc/subgid

--- a/cmd/analyze-hybrid.go
+++ b/cmd/analyze-hybrid.go
@@ -226,8 +226,8 @@ func (a *analyzeCommand) setupNetworkProvider(ctx context.Context, providerName 
 		providerSpecificConfig["lspServerName"] = providerName
 		providerSpecificConfig["lspServerPath"] = JDTLSBinLocation
 		providerSpecificConfig["bundles"] = JavaBundlesLocation
-		providerSpecificConfig["depOpenSourceLabelsFile"] = "/usr/local/etc/maven.default.index"
-		providerSpecificConfig["mavenIndexPath"] = "/usr/local/etc/maven-index.txt"
+		providerSpecificConfig["mavenIndexPath"] = MavenIndexPath
+		providerSpecificConfig["depOpenSourceLabelsFile"] = DepOpenSourceLabels
 		if a.mavenSettingsFile != "" {
 			// Use container path where settings.xml is mounted (copied by getConfigVolumes)
 			providerSpecificConfig["mavenSettingsFile"] = path.Join(util.ConfigMountPath, "settings.xml")
@@ -972,6 +972,10 @@ func (a *analyzeCommand) RunAnalysisHybridInProcess(ctx context.Context) error {
 		return err
 	}
 	a.log.Info("[TIMING] Static report generation complete", "duration_ms", time.Since(startStaticReport).Milliseconds())
+
+	if err := a.getProviderLogs(ctx); err != nil {
+		a.log.Error(err, "failed to get provider logs")
+	}
 
 	// Print results summary (only in progress mode, not in --no-progress mode)
 	progressMode.Println("\nResults:")

--- a/cmd/settings.go
+++ b/cmd/settings.go
@@ -15,6 +15,8 @@ var (
 	RootCommandName      = "kantra"
 	JavaBundlesLocation  = "/jdtls/java-analyzer-bundle/java-analyzer-bundle.core/target/java-analyzer-bundle.core-1.0.0-SNAPSHOT.jar"
 	JDTLSBinLocation     = "/jdtls/bin/jdtls"
+	MavenIndexPath       = "/usr/local/etc/maven-index.txt"
+	DepOpenSourceLabels  = "/usr/local/etc/maven.default.index"
 	RulesetsLocation     = "rulesets"
 	JavaProviderImage    = "quay.io/konveyor/java-external-provider"
 	GenericProviderImage = "quay.io/konveyor/generic-external-provider"

--- a/pkg/testing/runner.go
+++ b/pkg/testing/runner.go
@@ -70,7 +70,7 @@ var defaultProviderConfig = []provider.Config{
 				AnalysisMode: provider.FullAnalysisMode,
 				ProviderSpecificConfig: map[string]interface{}{
 					"lspServerName":                 "generic",
-					provider.LspServerPathConfigKey: "/root/go/bin/gopls",
+					provider.LspServerPathConfigKey: "/usr/local/bin/gopls",
 					"lspServerArgs":                 []string{},
 					"dependencyProviderPath":        "/usr/local/bin/golang-dependency-provider",
 				},


### PR DESCRIPTION
Fixes #663  
Fixes #662 
Fixes #642 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Provider logs are now automatically retrieved and processed during analysis, with error reporting when retrieval fails.

* **Improvements**
  * Enhanced TypeScript/runtime tooling available in the environment, including the language server and npm-installed tools.
  * Updated Go language support configuration for improved reliability and standard path compatibility.
  * Default local index/config paths adjusted for Java-related dependency handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->