### PR TITLE
Use Default Rules for Profile if Default Source or Target

### DIFF
--- a/pkg/profile/profile.go
+++ b/pkg/profile/profile.go
@@ -112,7 +112,11 @@ func SetSettingsFromProfile(path string, cmd *cobra.Command, settings *ProfileSe
 		}
 		if len(profileRules) > 0 {
 			settings.Rules = append(settings.Rules, profileRules...)
-			settings.EnableDefaultRulesets = false
+			targetFlag := cmd.Flags().Lookup("target")
+			sourceFlag := cmd.Flags().Lookup("source")
+			if (targetFlag == nil || !targetFlag.Changed) && (sourceFlag == nil || !sourceFlag.Changed) {
+				settings.EnableDefaultRulesets = false
+			}
 		}
 	}
 


### PR DESCRIPTION
Fixes #693 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed profile rule loading behavior: default rulesets are now conditionally disabled based on explicit flag usage, providing more accurate control over rule configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->