### PR TITLE
Fix profile validation & using default rules with profiles

### DIFF
--- a/cmd/analyze.go
+++ b/cmd/analyze.go
@@ -84,6 +84,7 @@ type analyzeCommand struct {
 	noProgress               bool
 	overrideProviderSettings string
 	profileDir               string
+	profilePath              string
 	AnalyzeCommandContext
 }
 
@@ -120,7 +121,16 @@ func NewAnalyzeCmd(log logr.Logger) *cobra.Command {
 			}
 			analyzeCmd.kantraDir = kantraDir
 			analyzeCmd.log.Info("found kantra dir", "dir", kantraDir)
-			err = analyzeCmd.Validate(cmd.Context(), cmd)
+
+			foundProfile, err := analyzeCmd.ValidateAndLoadProfile()
+			if err != nil {
+				return err
+			}
+			if analyzeCmd.profileDir == "" && foundProfile == nil {
+				analyzeCmd.log.V(7).Info("did not find profile in default path")
+			}
+
+			err = analyzeCmd.Validate(cmd.Context(), cmd, foundProfile)
 			if err != nil {
 				log.Error(err, "failed to validate flags")
 				return err
@@ -147,36 +157,12 @@ func NewAnalyzeCmd(log logr.Logger) *cobra.Command {
 				analyzeCmd.runLocal = false
 			}
 
-			// get profile options for analysis
-			if analyzeCmd.profileDir != "" {
-				stat, err := os.Stat(analyzeCmd.profileDir)
-				if err != nil {
-					return fmt.Errorf("failed to stat profiles directory %s: %w", analyzeCmd.profileDir, err)
-				}
-
-				if !stat.IsDir() {
-					return fmt.Errorf("found profiles path %s is not a directory", analyzeCmd.profileDir)
-				}
-				profilePath := filepath.Join(analyzeCmd.profileDir, "profile.yaml")
-				err = analyzeCmd.applyProfileSettings(profilePath, cmd)
-				if err != nil {
+			// apply profile settings if a profile found
+			if analyzeCmd.profilePath != "" {
+				analyzeCmd.log.Info("using profile", "profile", analyzeCmd.profilePath)
+				if err := analyzeCmd.applyProfileSettings(analyzeCmd.profilePath, cmd); err != nil {
 					analyzeCmd.log.Error(err, "failed to get settings from profile")
 					return err
-				}
-			} else {
-				// check for a single profile in default path
-				profilesDir := filepath.Join(analyzeCmd.input, profile.Profiles)
-				profilePath, err := profile.FindSingleProfile(profilesDir)
-				if err != nil {
-					analyzeCmd.log.Error(err, "did not find valid profile in default path")
-				}
-				if profilePath != "" {
-					analyzeCmd.log.Info("using found profile", "profile", profilePath)
-					err = analyzeCmd.applyProfileSettings(profilePath, cmd)
-					if err != nil {
-						analyzeCmd.log.Error(err, "failed to get settings from profile")
-						return err
-					}
 				}
 			}
 
@@ -349,7 +335,7 @@ func NewAnalyzeCmd(log logr.Logger) *cobra.Command {
 	return analyzeCommand
 }
 
-func (a *analyzeCommand) Validate(ctx context.Context, cmd *cobra.Command) error {
+func (a *analyzeCommand) Validate(ctx context.Context, cmd *cobra.Command, foundProfile *profile.AnalysisProfile) error {
 	if a.listSources || a.listTargets || a.listProviders {
 		return nil
 	}
@@ -504,7 +490,7 @@ func (a *analyzeCommand) Validate(ctx context.Context, cmd *cobra.Command) error
 	if absPath, err := filepath.Abs(a.mavenSettingsFile); a.mavenSettingsFile != "" && err == nil {
 		a.mavenSettingsFile = absPath
 	}
-	if !a.enableDefaultRulesets && len(a.rules) == 0 {
+	if !a.enableDefaultRulesets && len(a.rules) == 0 && foundProfile == nil {
 		return fmt.Errorf("must specify rules if default rulesets are not enabled")
 	}
 	return nil
@@ -539,6 +525,38 @@ func (a *analyzeCommand) CheckOverwriteOutput() error {
 		}
 	}
 	return nil
+}
+
+func (a *analyzeCommand) ValidateAndLoadProfile() (*profile.AnalysisProfile, error) {
+	if a.profileDir != "" {
+		stat, err := os.Stat(a.profileDir)
+		if err != nil {
+			return nil, fmt.Errorf("failed to stat profiles directory %s: %w", a.profileDir, err)
+		}
+		if !stat.IsDir() {
+			return nil, fmt.Errorf("found profiles path %s is not a directory", a.profileDir)
+		}
+		a.profilePath = filepath.Join(a.profileDir, "profile.yaml")
+	} else if a.input != "" {
+		profilesDir := filepath.Join(a.input, profile.Profiles)
+		foundPath, err := profile.FindSingleProfile(profilesDir)
+		if err != nil {
+			// do not error if no profile is found
+			return nil, nil
+		}
+		if foundPath != "" {
+			a.profilePath = foundPath
+		}
+	}
+	if a.profilePath == "" {
+		return nil, nil
+	}
+	foundProfile, err := profile.UnmarshalProfile(a.profilePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load profile %s: %w", a.profilePath, err)
+	}
+
+	return foundProfile, nil
 }
 
 func (a *analyzeCommand) validateProviders(providers []string) error {

--- a/cmd/analyze.go
+++ b/cmd/analyze.go
@@ -490,8 +490,11 @@ func (a *analyzeCommand) Validate(ctx context.Context, cmd *cobra.Command, found
 	if absPath, err := filepath.Abs(a.mavenSettingsFile); a.mavenSettingsFile != "" && err == nil {
 		a.mavenSettingsFile = absPath
 	}
-	if !a.enableDefaultRulesets && len(a.rules) == 0 && foundProfile == nil {
-		return fmt.Errorf("must specify rules if default rulesets are not enabled")
+	if !a.enableDefaultRulesets && len(a.rules) == 0 {
+		profileHasRules := foundProfile != nil && profile.ProfileHasRules(a.profilePath)
+		if !profileHasRules {
+			return fmt.Errorf("must specify rules if default rulesets are not enabled")
+		}
 	}
 	return nil
 }

--- a/pkg/profile/profile.go
+++ b/pkg/profile/profile.go
@@ -2,6 +2,7 @@ package profile
 
 import (
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -43,6 +44,29 @@ type LabelSelector struct {
 
 type AnalysisRules struct {
 	Labels LabelSelector `json:"labels,omitempty" yaml:"labels,omitempty"`
+}
+
+func ProfileHasRules(profilePath string) bool {
+	if profilePath == "" {
+		return false
+	}
+	rulesDir := filepath.Join(filepath.Dir(profilePath), "rules")
+	stat, err := os.Stat(rulesDir)
+	if err != nil || !stat.IsDir() {
+		return false
+	}
+	var found bool
+	_ = filepath.WalkDir(rulesDir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !d.IsDir() && strings.HasSuffix(strings.ToLower(d.Name()), ".yaml") {
+			found = true
+			return filepath.SkipAll
+		}
+		return nil
+	})
+	return found
 }
 
 type ProfileSettings struct {

--- a/pkg/profile/profile.go
+++ b/pkg/profile/profile.go
@@ -46,13 +46,8 @@ type AnalysisRules struct {
 	Labels LabelSelector `json:"labels,omitempty" yaml:"labels,omitempty"`
 }
 
-func ProfileHasRules(profilePath string) bool {
-	if profilePath == "" {
-		return false
-	}
-	rulesDir := filepath.Join(filepath.Dir(profilePath), "rules")
-	stat, err := os.Stat(rulesDir)
-	if err != nil || !stat.IsDir() {
+func ProfileHasRules(rulesDir string) bool {
+	if rulesDir == "" {
 		return false
 	}
 	var found bool
@@ -60,7 +55,8 @@ func ProfileHasRules(profilePath string) bool {
 		if err != nil {
 			return err
 		}
-		if !d.IsDir() && strings.HasSuffix(strings.ToLower(d.Name()), ".yaml") {
+		name := strings.ToLower(d.Name())
+		if !d.IsDir() && (strings.HasSuffix(name, ".yaml") || strings.HasSuffix(name, ".yml")) {
 			found = true
 			return filepath.SkipAll
 		}
@@ -256,6 +252,10 @@ func GetRulesInProfile(profileDir string) ([]string, error) {
 
 	if !stat.IsDir() {
 		return nil, fmt.Errorf("rules path %s is not a directory", rulesDir)
+	}
+
+	if !ProfileHasRules(rulesDir) {
+		return nil, nil
 	}
 	entries, err := os.ReadDir(rulesDir)
 	if err != nil {


### PR DESCRIPTION
Fixes #702 
Fixes #703 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Analyze command loads and applies analysis profiles from configured or default locations; validation now respects profile-driven settings and logs profile usage or absence.
  * Profile inspection detects presence of rule files and default labels to influence default-ruleset behavior.

* **Refactor**
  * Streamlined, path-driven profile resolution and application flow with clearer conditional logging.

* **Bug Fixes**
  * More descriptive errors for profile resolution and loading failures.

* **Tests**
  * Extensive unit tests for profile loading, rule detection, validation, and default-ruleset scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->