### PR TITLE
Handle windows drive's for host root in hybrid analysis mode

### DIFF
--- a/cmd/analyze-hybrid.go
+++ b/cmd/analyze-hybrid.go
@@ -468,7 +468,7 @@ func (a *analyzeCommand) setupBuiltinProviderHybrid(ctx context.Context, additio
 		return nil, nil, err
 	}
 
-	analysisLog.V(1).Info("starting provider", "provider", "builtin", "config", builtinConfig, "additionalConfigs", additionalConfigs, "locations", providerLocations)
+	analysisLog.V(1).Info("starting provider", "provider", "builtin", "locations", providerLocations)
 	if _, err := builtinProvider.ProviderInit(ctx, additionalConfigs); err != nil {
 		a.log.Error(err, "unable to init the builtin provider")
 		return nil, nil, err


### PR DESCRIPTION
The old logic assumed everything was on the `C` drive, but that is not the case. 

This will capture the match, and pull out the drive letter, from there, we can convert it back to a windows host name to be handled by the builtin provider correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows container-to-host path translation in hybrid analysis, correctly preserving drive letters and path separators to avoid misresolved volume paths.

* **Chores**
  * Extended startup and analysis logging to include provider locations and host-root mapping information for clearer diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->