### PR TITLE
:bug: On windows with certain Quarkus applications Java is not found as a language

### DIFF
--- a/cmd/analyze.go
+++ b/cmd/analyze.go
@@ -185,15 +185,17 @@ func NewAnalyzeCmd(log logr.Logger) *cobra.Command {
 			if analyzeCmd.providersMap == nil {
 				analyzeCmd.providersMap = make(map[string]ProviderInit)
 			}
-			components, err := recognizer.DetectComponentsInRoot(analyzeCmd.input)
-			if err != nil {
-				log.Error(err, "Could not determine programming language components")
-				return err
-			}
 			languages := map[string]model.Language{}
-			for _, c := range components {
-				for _, l := range c.Languages {
-					languages[l.Name] = l
+			if !analyzeCmd.isFileInput {
+				components, err := recognizer.DetectComponents(analyzeCmd.input)
+				if err != nil {
+					log.Error(err, "Could not determine programming language components")
+					return err
+				}
+				for _, c := range components {
+					for _, l := range c.Languages {
+						languages[l.Name] = l
+					}
 				}
 			}
 			if analyzeCmd.listLanguages {
@@ -214,6 +216,7 @@ func NewAnalyzeCmd(log logr.Logger) *cobra.Command {
 			if analyzeCmd.isFileInput {
 				foundProviders = append(foundProviders, util.JavaProvider)
 			} else {
+				var err error
 				foundProviders, err = analyzeCmd.setProviders(analyzeCmd.provider, maps.Values(languages), foundProviders)
 				if err != nil {
 					log.Error(err, "failed to set provider info")
@@ -277,7 +280,7 @@ func NewAnalyzeCmd(log logr.Logger) *cobra.Command {
 				// (providersMap will be empty, hybrid mode handles this)
 			}
 
-			err = analyzeCmd.setProviderInitInfo(foundProviders)
+			err := analyzeCmd.setProviderInitInfo(foundProviders)
 			if err != nil {
 				log.Error(err, "failed to set provider init info")
 				return err

--- a/cmd/command-context.go
+++ b/cmd/command-context.go
@@ -49,6 +49,13 @@ func (c *AnalyzeCommandContext) setProviders(providers []string, languages []mod
 		}
 		return foundProviders, nil
 	}
+	validProvs := map[string]any{
+		util.JavaProvider:   nil,
+		util.PythonProvider: nil,
+		util.GoProvider:     nil,
+		util.NodeJSProvider: nil,
+		util.CsharpProvider: nil,
+	}
 	for _, l := range languages {
 		if l.CanBeComponent {
 			c.log.V(5).Info("Got language", "component language", l)
@@ -61,7 +68,11 @@ func (c *AnalyzeCommandContext) setProviders(providers []string, languages []mod
 			if l.Name == "JavaScript" || l.Name == "TypeScript" {
 				foundProviders = append(foundProviders, util.NodeJSProvider)
 
-			} else {
+			} else if _, ok := validProvs[strings.ToLower(l.Name)]; ok && l.Weight > .001 {
+				foundProviders = append(foundProviders, strings.ToLower(l.Name))
+			} else if l.Weight > .1 {
+				// Because we have control of the weight, if there is not a default
+				// provider for this language, lets make it have a higher level to clear.
 				foundProviders = append(foundProviders, strings.ToLower(l.Name))
 			}
 		}

--- a/cmd/command-context_test.go
+++ b/cmd/command-context_test.go
@@ -76,10 +76,12 @@ func Test_AnalyzeCommandContext_setProviders_EmptyProvidersUsesLanguages(t *test
 		{
 			Name:           "Java",
 			CanBeComponent: true,
+			Weight:         0.2,
 		},
 		{
 			Name:           "Go",
 			CanBeComponent: true,
+			Weight:         0.01,
 		},
 	}
 	foundProviders := []string{}
@@ -104,6 +106,43 @@ func Test_AnalyzeCommandContext_setProviders_EmptyProvidersUsesLanguages(t *test
 	}
 	if !providerMap["go"] {
 		t.Error("setProviders() missing go provider from language detection")
+	}
+}
+
+func Test_AnalyzeCommandContext_setProviders_NonDefaultLanguage(t *testing.T) {
+	ctx := &AnalyzeCommandContext{
+		log:          logr.Discard(),
+		providersMap: make(map[string]ProviderInit),
+	}
+
+	providers := []string{}
+	languages := []model.Language{
+		{
+			Name:           "Rust",
+			CanBeComponent: true,
+			Weight:         .3,
+		},
+		{
+			Name:           "PHP",
+			CanBeComponent: true,
+			Weight:         .03,
+		},
+	}
+	foundProviders := []string{}
+
+	result, err := ctx.setProviders(providers, languages, foundProviders)
+	if err != nil {
+		t.Fatalf("setProviders() error = %v", err)
+	}
+
+	// Rust should be the only provider
+	if len(result) != 1 {
+		t.Errorf("setProviders() returned %d providers, want 1", len(result))
+	}
+
+	if result[0] != "rust" {
+		t.Errorf("setProviders() returned provider %s for non default Rust, want %s",
+			result[0], "Rust")
 	}
 }
 


### PR DESCRIPTION
This happens because the weight of the Java language falls below the threshold for the reconginzer. Using the components, we can assign our own weights; here, we will assign different weights depending on whether there is a default provider for that language.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved component-based language detection for non-file inputs and clearer "Could not determine programming language components" feedback.
  * Language listings now filter out low-weight entries to reduce noise.
  * Stricter provider selection for non-default languages using a validated provider set and higher weight thresholds.

* **Tests**
  * Added tests for language-based provider auto-detection, including mappings for non-default languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->