### PR TITLE
:bug: handle input as a file for looking for profiles

### DIFF
--- a/cmd/analyze.go
+++ b/cmd/analyze.go
@@ -536,6 +536,13 @@ func (a *analyzeCommand) ValidateAndLoadProfile() (*profile.AnalysisProfile, err
 		}
 		a.profilePath = filepath.Join(a.profileDir, "profile.yaml")
 	} else if a.input != "" {
+		stat, err := os.Stat(a.input)
+		if err != nil {
+			return nil, err
+		}
+		if !stat.IsDir() {
+			return nil, nil
+		}
 		profilesDir := filepath.Join(a.input, profile.Profiles)
 		foundPath, err := profile.FindSingleProfile(profilesDir)
 		if err != nil {

--- a/cmd/analyze_test.go
+++ b/cmd/analyze_test.go
@@ -737,6 +737,22 @@ func Test_analyzeCommand_ValidateAndLoadProfile(t *testing.T) {
 			wantErr:        true,
 			errContains:    "not a directory",
 		},
+		{
+			name: "input is not directory",
+			setup: func(t *testing.T) *analyzeCommand {
+				tmpDir, err := os.MkdirTemp("", "test-input-")
+				if err != nil {
+					t.Fatalf("MkdirTemp: %v", err)
+				}
+				t.Cleanup(func() { os.RemoveAll(tmpDir) })
+				if err := os.WriteFile(filepath.Join(tmpDir, "file_input"), []byte("not a dir"), 0644); err != nil {
+					t.Fatalf("WriteFile: %v", err)
+				}
+				return &analyzeCommand{input: filepath.Join(tmpDir, "file_input")}
+			},
+			wantProfileNil: true,
+			wantErr:        false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The analyze command now properly validates input paths and enforces directory requirements. Non-directory file inputs are rejected with a clear error message instead of attempting to proceed with profile loading logic. This prevents unexpected behavior when users provide file paths instead of directory paths.

* **Tests**
  * Added comprehensive test coverage for input validation, specifically testing the scenario where a file path is provided instead of a directory path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->