### PR TITLE
Fix CCM for binary apps

### DIFF
--- a/cmd/analyze.go
+++ b/cmd/analyze.go
@@ -349,10 +349,6 @@ func (a *analyzeCommand) Validate(ctx context.Context, cmd *cobra.Command, found
 		return nil
 	}
 
-	if a.labelSelector != "" && (len(a.sources) > 0 || len(a.targets) > 0) {
-		return fmt.Errorf("must not specify label-selector and sources or targets")
-	}
-
 	for _, rulePath := range a.rules {
 		if _, err := os.Stat(rulePath); rulePath != "" && err != nil {
 			return fmt.Errorf("%w failed to stat rules at path %s", err, rulePath)

--- a/pkg/profile/application.go
+++ b/pkg/profile/application.go
@@ -5,6 +5,7 @@ type Application struct {
 	ID         uint        `json:"id" yaml:"id"`
 	Name       string      `json:"name" yaml:"name"`
 	Repository *Repository `json:"repository,omitempty" yaml:"repository,omitempty"`
+	Binary     string      `json:"binary,omitempty" yaml:"binary,omitempty"`
 }
 
 type Resource struct {


### PR DESCRIPTION
Fixes #706 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added binary-based application lookup mode alongside URL-based lookup
  * Introduced --binary and --profile-path command flags
  * Applications now support binary field in profiles

* **Bug Fixes**
  * Removed validation restriction preventing label-selector use with sources or targets

<!-- end of auto-generated comment: release notes by coderabbit.ai -->