### PR TITLE
:bug: Handling providers that do not have logging

### DIFF
--- a/cmd/analyze.go
+++ b/cmd/analyze.go
@@ -1056,7 +1056,7 @@ func (a *analyzeCommand) RunProvidersHostNetwork(ctx context.Context, volName st
 
 	for prov, init := range a.providersMap {
 		args := []string{fmt.Sprintf("--port=%v", init.port)}
-		if a.logLevel != nil {
+		if a.logLevel != nil && init.provider.SupportsLogLevel() {
 			args = append(args, fmt.Sprintf("--log-level=%v", *a.logLevel))
 		}
 

--- a/pkg/provider/csharp.go
+++ b/pkg/provider/csharp.go
@@ -8,7 +8,12 @@ import (
 )
 
 type CsharpProvider struct {
+	baseProvider
 	config provider.Config
+}
+
+func (p *CsharpProvider) SupportsLogLevel() bool {
+	return false
 }
 
 func (p *CsharpProvider) GetConfigVolume(c ConfigInput) (provider.Config, error) {

--- a/pkg/provider/go.go
+++ b/pkg/provider/go.go
@@ -8,6 +8,7 @@ import (
 )
 
 type GoProvider struct {
+	baseProvider
 	config provider.Config
 }
 

--- a/pkg/provider/java.go
+++ b/pkg/provider/java.go
@@ -13,6 +13,7 @@ import (
 )
 
 type JavaProvider struct {
+	baseProvider
 	config provider.Config
 }
 

--- a/pkg/provider/nodejs.go
+++ b/pkg/provider/nodejs.go
@@ -8,6 +8,7 @@ import (
 )
 
 type NodeJsProvider struct {
+	baseProvider
 	config provider.Config
 }
 

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -24,4 +24,11 @@ type ConfigInput struct {
 
 type Provider interface {
 	GetConfigVolume(input ConfigInput) (provider.Config, error)
+	SupportsLogLevel() bool
+}
+
+type baseProvider struct{}
+
+func (b *baseProvider) SupportsLogLevel() bool {
+	return true
 }

--- a/pkg/provider/python.go
+++ b/pkg/provider/python.go
@@ -8,6 +8,7 @@ import (
 )
 
 type PythonProvider struct {
+	baseProvider
 	config provider.Config
 }
 


### PR DESCRIPTION
via the `--log-level` flag

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed log-level configuration handling to conditionally apply only to providers that support it, preventing unnecessary or unsupported arguments from being passed to language providers.

* **Refactor**
  * Enhanced the provider capability detection system to accurately identify which providers support log-level configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->