### PR TITLE
Run default rules for given provider

### DIFF
--- a/cmd/analyze-bin.go
+++ b/cmd/analyze-bin.go
@@ -303,8 +303,8 @@ func (a *analyzeCommand) RunAnalysisContainerless(ctx context.Context) error {
 	ruleSets := []engine.RuleSet{}
 	needProviders := map[string]provider.InternalProviderClient{}
 
-	if a.enableDefaultRulesets {
-		a.rules = append(a.rules, filepath.Join(a.kantraDir, RulesetsLocation))
+	if p := a.defaultRulesetPathContainerless(); p != "" {
+		a.rules = append(a.rules, p)
 	}
 	providerConditions := map[string][]provider.ConditionsByCap{}
 
@@ -468,6 +468,13 @@ func (a *analyzeCommand) ValidateContainerless(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+func (a *analyzeCommand) defaultRulesetPathContainerless() string {
+	if !a.enableDefaultRulesets {
+		return ""
+	}
+	return filepath.Join(a.kantraDir, RulesetsLocation, util.JavaProvider)
 }
 
 func (a *analyzeCommand) listLabelsContainerless(ctx context.Context) error {

--- a/cmd/analyze-bin_test.go
+++ b/cmd/analyze-bin_test.go
@@ -295,6 +295,49 @@ func TestRunAnalysisContainerless_EngineCreationPath(t *testing.T) {
 	}
 }
 
+func TestDefaultRulesetPathContainerless(t *testing.T) {
+	tests := []struct {
+		name                  string
+		enableDefaultRulesets bool
+		kantraDir             string
+		wantPath              string
+	}{
+		{
+			name:                  "enabled returns kantraDir/rulesets/java",
+			enableDefaultRulesets: true,
+			kantraDir:             "/.kantra",
+			wantPath:              "/.kantra/rulesets/java",
+		},
+		{
+			name:                  "disabled returns empty",
+			enableDefaultRulesets: false,
+			kantraDir:             "/.kantra",
+			wantPath:              "",
+		},
+		{
+			name:                  "enabled with custom kantra dir",
+			enableDefaultRulesets: true,
+			kantraDir:             "/home/user/.kantra",
+			wantPath:              "/home/user/.kantra/rulesets/java",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := &analyzeCommand{
+				enableDefaultRulesets: tt.enableDefaultRulesets,
+				AnalyzeCommandContext: AnalyzeCommandContext{
+					kantraDir: tt.kantraDir,
+				},
+			}
+			got := a.defaultRulesetPathContainerless()
+			assert.Equal(t, tt.wantPath, filepath.ToSlash(got), "path should use java ruleset subdir (DefaultRulesetDir mapping)")
+			if tt.wantPath != "" {
+				assert.Equal(t, util.JavaProvider, filepath.Base(got))
+			}
+		})
+	}
+}
+
 func TestGradleSourcesTaskFileConfiguration(t *testing.T) {
 	a := analyzeCommand{}
 	a.AnalyzeCommandContext.kantraDir = "kantraDir"

--- a/cmd/analyze-hybrid.go
+++ b/cmd/analyze-hybrid.go
@@ -301,6 +301,24 @@ func (a *analyzeCommand) setupNetworkProvider(ctx context.Context, providerName 
 	return providerLocations, additionalBuiltinConfs, nil
 }
 
+func (a *analyzeCommand) defaultRulesetPathsForHybrid(rulesetsDir string) []string {
+	if rulesetsDir == "" {
+		return nil
+	}
+	var out []string
+	for provName := range a.providersMap {
+		rulesetSubdir, ok := util.DefaultRulesetDir[provName]
+		if !ok {
+			continue
+		}
+		p := filepath.Join(rulesetsDir, rulesetSubdir)
+		if _, err := os.Stat(p); err == nil {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
 // runParallelStartupTasks executes independent startup tasks concurrently for better performance.
 // Returns the volume name and rulesets directory on success.
 func (a *analyzeCommand) runParallelStartupTasks(ctx context.Context, containerLogWriter io.Writer) (volName string, rulesetsDir string, err error) {
@@ -540,9 +558,11 @@ func (a *analyzeCommand) RunAnalysisHybridInProcess(ctx context.Context) error {
 			return err
 		}
 
-		// Add extracted rulesets to rules list if we got any
+		// add rulesets for each running provider
 		if rulesetsDir != "" {
-			a.rules = append(a.rules, rulesetsDir)
+			for _, p := range a.defaultRulesetPathsForHybrid(rulesetsDir) {
+				a.rules = append(a.rules, p)
+			}
 		}
 
 		// For binary files, util.SourceMountPath includes the filename (e.g., /opt/input/source/app.war)

--- a/cmd/analyze.go
+++ b/cmd/analyze.go
@@ -252,9 +252,15 @@ func NewAnalyzeCmd(log logr.Logger) *cobra.Command {
 				log.Info("--run-local set to false. Running analysis in hybrid mode")
 			}
 
-			// default rulesets are only java rules
-			// may want to change this in the future
-			if len(foundProviders) > 0 && len(analyzeCmd.rules) == 0 && !slices.Contains(foundProviders, util.JavaProvider) {
+			// default rulesets exist for java, nodejs, and csharp
+			hasProviderWithDefaultRules := false
+			for _, p := range foundProviders {
+				if _, ok := util.DefaultRulesetDir[p]; ok {
+					hasProviderWithDefaultRules = true
+					break
+				}
+			}
+			if len(foundProviders) > 0 && len(analyzeCmd.rules) == 0 && !hasProviderWithDefaultRules {
 				return fmt.Errorf("no providers found with default rules. Use --rules option")
 			}
 

--- a/cmd/hybrid_integration_test.go
+++ b/cmd/hybrid_integration_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	"github.com/konveyor-ecosystem/kantra/pkg/util"
 )
 
 // TestWaitForProviderTimeout tests that waitForProvider correctly times out
@@ -294,6 +295,141 @@ func TestProviderEntrypointArgs(t *testing.T) {
 
 func uint32Ptr(u uint32) *uint32 {
 	return &u
+}
+
+func TestDefaultRulesetPathsForHybrid(t *testing.T) {
+	// Create temp dir with default ruleset subdirs: java, nodejs, dotnet (no go/python)
+	tmpDir, err := os.MkdirTemp("", "test-hybrid-rulesets-")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+	for _, subdir := range []string{"java", "nodejs", "dotnet", "input"} {
+		if err := os.MkdirAll(filepath.Join(tmpDir, subdir), 0755); err != nil {
+			t.Fatalf("MkdirAll %s: %v", subdir, err)
+		}
+	}
+
+	tests := []struct {
+		name         string
+		providersMap map[string]ProviderInit
+		wantPaths    []string
+	}{
+		{
+			name: "java provider adds java ruleset",
+			providersMap: map[string]ProviderInit{
+				util.JavaProvider: {},
+			},
+			wantPaths: []string{filepath.Join(tmpDir, "java")},
+		},
+		{
+			name: "csharp provider maps to dotnet ruleset",
+			providersMap: map[string]ProviderInit{
+				util.CsharpProvider: {},
+			},
+			wantPaths: []string{filepath.Join(tmpDir, "dotnet")},
+		},
+		{
+			name: "java and nodejs add both rulesets",
+			providersMap: map[string]ProviderInit{
+				util.JavaProvider:   {},
+				util.NodeJSProvider: {},
+			},
+			wantPaths: []string{filepath.Join(tmpDir, "java"), filepath.Join(tmpDir, "nodejs")},
+		},
+		{
+			name: "go and python have no default ruleset dir",
+			providersMap: map[string]ProviderInit{
+				util.GoProvider:     {},
+				util.PythonProvider: {},
+			},
+			wantPaths: nil,
+		},
+		{
+			name: "mixed: java and go only adds java",
+			providersMap: map[string]ProviderInit{
+				util.JavaProvider: {},
+				util.GoProvider:   {},
+			},
+			wantPaths: []string{filepath.Join(tmpDir, "java")},
+		},
+		{
+			name:         "empty providersMap returns nil",
+			providersMap: map[string]ProviderInit{},
+			wantPaths:    nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := &analyzeCommand{
+				AnalyzeCommandContext: AnalyzeCommandContext{
+					log:          logr.Discard(),
+					providersMap: tt.providersMap,
+				},
+			}
+			got := a.defaultRulesetPathsForHybrid(tmpDir)
+			if len(tt.wantPaths) == 0 && len(got) == 0 {
+				return
+			}
+			if len(tt.wantPaths) != len(got) {
+				t.Errorf("defaultRulesetPathsForHybrid() returned %d paths, want %d: got %v", len(got), len(tt.wantPaths), got)
+				return
+			}
+			gotSet := make(map[string]struct{})
+			for _, p := range got {
+				gotSet[p] = struct{}{}
+			}
+			for _, want := range tt.wantPaths {
+				if _, ok := gotSet[want]; !ok {
+					t.Errorf("defaultRulesetPathsForHybrid() missing path %q, got %v", want, got)
+				}
+			}
+		})
+	}
+}
+
+// TestDefaultRulesetPathsForHybridEmptyDir verifies that empty rulesetsDir returns nil.
+func TestDefaultRulesetPathsForHybridEmptyDir(t *testing.T) {
+	a := &analyzeCommand{
+		AnalyzeCommandContext: AnalyzeCommandContext{
+			log: logr.Discard(),
+			providersMap: map[string]ProviderInit{
+				util.JavaProvider: {},
+			},
+		},
+	}
+	got := a.defaultRulesetPathsForHybrid("")
+	if got != nil {
+		t.Errorf("defaultRulesetPathsForHybrid(%q) = %v, want nil", "", got)
+	}
+}
+
+// TestDefaultRulesetPathsForHybridMissingSubdir verifies that when a provider has a
+// DefaultRulesetDir mapping but the subdir does not exist, that path is not included.
+func TestDefaultRulesetPathsForHybridMissingSubdir(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "test-hybrid-rulesets-missing-")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+	// Only create "java", not "nodejs"
+	if err := os.MkdirAll(filepath.Join(tmpDir, "java"), 0755); err != nil {
+		t.Fatalf("MkdirAll java: %v", err)
+	}
+	a := &analyzeCommand{
+		AnalyzeCommandContext: AnalyzeCommandContext{
+			log: logr.Discard(),
+			providersMap: map[string]ProviderInit{
+				util.JavaProvider:   {},
+				util.NodeJSProvider: {},
+			},
+		},
+	}
+	got := a.defaultRulesetPathsForHybrid(tmpDir)
+	want := []string{filepath.Join(tmpDir, "java")}
+	if len(got) != 1 || got[0] != want[0] {
+		t.Errorf("defaultRulesetPathsForHybrid() = %v, want %v (nodejs subdir missing so not added)", got, want)
+	}
 }
 
 // Helper function to check if a container image exists locally

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -58,6 +58,12 @@ const (
 	CsharpProvider = "csharp"
 )
 
+var DefaultRulesetDir = map[string]string{
+	JavaProvider:   "java",
+	NodeJSProvider: "nodejs",
+	CsharpProvider: "dotnet",
+}
+
 // valid java file extensions
 const (
 	JavaArchive       = ".jar"

--- a/test-data/analysis-output.yaml
+++ b/test-data/analysis-output.yaml
@@ -1,106 +1,3 @@
-- name: angular-12/angular-13
-  description: This ruleset provides guidance for migrating from angular-12 to angular-13
-  skipped:
-  - angular-12-to-angular-13-debugging-00000
-  - angular-12-to-angular-13-http-00000
-  - angular-12-to-angular-13-http-00010
-  - angular-12-to-angular-13-queries-00000
-  - angular-12-to-angular-13-queries-00010
-  - angular-12-to-angular-13-queries-00020
-  - angular-12-to-angular-13-router-00010
-- name: angular-14/angular-15
-  description: This ruleset provides guidance for migrating from angular-14 to angular-15
-  skipped:
-  - angular-14-to-angular-15-angular-router-upgrade-00000
-- name: angular-16/angular-17
-  description: This ruleset provides guidance for migrating from angular-16 to angular-17
-  skipped:
-  - angular-16-to-angular-17-angular-components-00000
-  - angular-16-to-angular-17-angular-decorators-00000
-  - angular-16-to-angular-17-angular-decorators-00010
-  - angular-16-to-angular-17-angular-decorators-00020
-  - angular-16-to-angular-17-angular-directives-00000
-  - angular-16-to-angular-17-angular-directives-00010
-  - angular-16-to-angular-17-angular-directives-00020
-- name: angular-16/angular-21
-  description: This ruleset provides guidance for migrating from angular-16 to angular-21
-  skipped:
-  - angular-16-to-angular-21-import-path-change-00000
-  - angular-16-to-angular-21-import-path-change-00010
-- name: angular-2/angular-8
-  description: This ruleset provides guidance for migrating from angular-2 to angular-8
-  skipped:
-  - angular-2-to-angular-8-syntax-update-00000
-- name: angular-9/angular-10
-  description: This ruleset provides guidance for migrating from angular-9 to angular-10
-  skipped:
-  - angular-9-to-angular-10-build-optimization-00000
-- name: angularjs/angular
-  description: This ruleset provides guidance for migrating from angularjs to angular
-  skipped:
-  - angularjs-to-angular-bootstrap-00000
-  - angularjs-to-angular-bootstrap-00010
-  - angularjs-to-angular-bootstrap-00020
-  - angularjs-to-angular-components-00000
-  - angularjs-to-angular-dependency-injection-00000
-  - angularjs-to-angular-directives-00000
-  - angularjs-to-angular-events-00000
-  - angularjs-to-angular-events-00010
-  - angularjs-to-angular-events-00020
-  - angularjs-to-angular-http-service-00000
-  - angularjs-to-angular-http-service-00010
-  - angularjs-to-angular-http-service-00020
-  - angularjs-to-angular-http-service-00030
-  - angularjs-to-angular-http-service-00040
-  - angularjs-to-angular-interpolation-00000
-  - angularjs-to-angular-location-service-00000
-  - angularjs-to-angular-location-service-00010
-  - angularjs-to-angular-location-service-00020
-  - angularjs-to-angular-location-service-00030
-  - angularjs-to-angular-module-system-00000
-  - angularjs-to-angular-module-system-00010
-  - angularjs-to-angular-module-system-00020
-  - angularjs-to-angular-module-system-00030
-  - angularjs-to-angular-pipes-00000
-  - angularjs-to-angular-pipes-00010
-  - angularjs-to-angular-promises-00000
-  - angularjs-to-angular-promises-00010
-  - angularjs-to-angular-promises-00020
-  - angularjs-to-angular-promises-00030
-  - angularjs-to-angular-root-scope-00000
-  - angularjs-to-angular-routing-00000
-  - angularjs-to-angular-routing-00010
-  - angularjs-to-angular-routing-00020
-  - angularjs-to-angular-routing-00030
-  - angularjs-to-angular-scope-variables-00000
-  - angularjs-to-angular-services-00000
-  - angularjs-to-angular-services-00010
-  - angularjs-to-angular-template-syntax-00000
-  - angularjs-to-angular-template-syntax-00010
-  - angularjs-to-angular-template-syntax-00020
-  - angularjs-to-angular-template-syntax-00030
-  - angularjs-to-angular-template-syntax-00040
-  - angularjs-to-angular-template-syntax-00050
-  - angularjs-to-angular-template-syntax-00060
-  - angularjs-to-angular-template-syntax-00070
-  - angularjs-to-angular-template-syntax-00080
-  - angularjs-to-angular-template-syntax-00090
-  - angularjs-to-angular-timeout-interval-00000
-  - angularjs-to-angular-timeout-interval-00010
-  - angularjs-to-angular-watch-digest-00000
-  - angularjs-to-angular-watch-digest-00010
-  - angularjs-to-angular-watch-digest-00020
-- name: astro-v4/astro-v5
-  description: This ruleset provides guidance for migrating from Astro v4 to Astro
-    v5
-  skipped:
-  - astro-4-to-astro-5-api-removal-00000
-  - astro-4-to-astro-5-api-removal-00001
-  - astro-4-to-astro-5-api-removal-00002
-  - astro-4-to-astro-5-api-removal-00003
-  - astro-4-to-astro-5-async-changes-00000
-  - astro-4-to-astro-5-css-changes-00000
-  - astro-4-to-astro-5-markdown-00000
 - name: azure/springboot
   description: Recommend OpenFeign instead of Feign.
   skipped:
@@ -666,9 +563,6 @@
   - windup-discover-jpa-configuration
   - windup-discover-spring-configuration
   - windup-discover-web-configuration
-- name: dotnet/dotnetframework
-  description: This ruleset provides analysis with respect to API changes between
-    .NET Framework and newer versions of .NET.
 - name: droolsjbpm
   description: This ruleset provides help for migrating to a unified KIE (Knowledge
     Is Everything) API in the upgrade from version 5 to 6.
@@ -1926,103 +1820,6 @@
   skipped:
   - os-specific-00001
   - os-specific-00002
-- name: patternfly-v5/patternfly-v6
-  description: This ruleset provides guidance for migrating from patternfly-v5 to
-    patternfly-v6
-  skipped:
-  - patternfly-v5-to-patternfly-v6-breakpoints-00000
-  - patternfly-v5-to-patternfly-v6-breakpoints-00010
-  - patternfly-v5-to-patternfly-v6-breakpoints-00020
-  - patternfly-v5-to-patternfly-v6-breakpoints-00030
-  - patternfly-v5-to-patternfly-v6-breakpoints-00040
-  - patternfly-v5-to-patternfly-v6-breakpoints-00050
-  - patternfly-v5-to-patternfly-v6-breakpoints-00060
-  - patternfly-v5-to-patternfly-v6-breakpoints-00070
-  - patternfly-v5-to-patternfly-v6-breakpoints-00080
-  - patternfly-v5-to-patternfly-v6-breakpoints-00090
-  - patternfly-v5-to-patternfly-v6-breakpoints-00100
-  - patternfly-v5-to-patternfly-v6-charts-00000
-  - patternfly-v5-to-patternfly-v6-chip-00000
-  - patternfly-v5-to-patternfly-v6-chip-00010
-  - patternfly-v5-to-patternfly-v6-cleanup-00000
-  - patternfly-v5-to-patternfly-v6-cleanup-00010
-  - patternfly-v5-to-patternfly-v6-component-groups-00010
-  - patternfly-v5-to-patternfly-v6-component-props-00270
-  - patternfly-v5-to-patternfly-v6-component-props-00280
-  - patternfly-v5-to-patternfly-v6-component-props-00290
-  - patternfly-v5-to-patternfly-v6-component-props-00300
-  - patternfly-v5-to-patternfly-v6-component-props-00310
-  - patternfly-v5-to-patternfly-v6-component-props-00330
-  - patternfly-v5-to-patternfly-v6-component-props-00350
-  - patternfly-v5-to-patternfly-v6-component-props-00380
-  - patternfly-v5-to-patternfly-v6-component-props-00390
-  - patternfly-v5-to-patternfly-v6-component-props-00400
-  - patternfly-v5-to-patternfly-v6-component-renames-00000
-  - patternfly-v5-to-patternfly-v6-component-renames-00010
-  - patternfly-v5-to-patternfly-v6-component-renames-00020
-  - patternfly-v5-to-patternfly-v6-components-00050
-  - patternfly-v5-to-patternfly-v6-css-classes-00000
-  - patternfly-v5-to-patternfly-v6-css-tokens-00000
-  - patternfly-v5-to-patternfly-v6-css-units-00000
-  - patternfly-v5-to-patternfly-v6-css-units-00010
-  - patternfly-v5-to-patternfly-v6-css-units-00020
-  - patternfly-v5-to-patternfly-v6-css-units-00030
-  - patternfly-v5-to-patternfly-v6-css-values-00000
-  - patternfly-v5-to-patternfly-v6-css-values-00010
-  - patternfly-v5-to-patternfly-v6-css-values-00020
-  - patternfly-v5-to-patternfly-v6-css-values-00030
-  - patternfly-v5-to-patternfly-v6-css-values-00040
-  - patternfly-v5-to-patternfly-v6-css-variables-00000
-  - patternfly-v5-to-patternfly-v6-deprecated-components-00000
-  - patternfly-v5-to-patternfly-v6-deprecated-components-00010
-  - patternfly-v5-to-patternfly-v6-deprecated-components-00020
-  - patternfly-v5-to-patternfly-v6-deprecated-components-00030
-  - patternfly-v5-to-patternfly-v6-deprecated-components-00040
-  - patternfly-v5-to-patternfly-v6-drag-drop-00000
-  - patternfly-v5-to-patternfly-v6-drag-drop-00010
-  - patternfly-v5-to-patternfly-v6-drag-drop-00020
-  - patternfly-v5-to-patternfly-v6-drawer-00040
-  - patternfly-v5-to-patternfly-v6-dual-list-selector-00000
-  - patternfly-v5-to-patternfly-v6-dual-list-selector-00010
-  - patternfly-v5-to-patternfly-v6-empty-state-00000
-  - patternfly-v5-to-patternfly-v6-empty-state-00010
-  - patternfly-v5-to-patternfly-v6-import-path-00000
-  - patternfly-v5-to-patternfly-v6-import-path-00010
-  - patternfly-v5-to-patternfly-v6-import-path-00020
-  - patternfly-v5-to-patternfly-v6-import-path-00030
-  - patternfly-v5-to-patternfly-v6-import-paths-00000
-  - patternfly-v5-to-patternfly-v6-imports-00000
-  - patternfly-v5-to-patternfly-v6-interface-renames-00000
-  - patternfly-v5-to-patternfly-v6-patternfly-v6-00000
-  - patternfly-v5-to-patternfly-v6-patternfly-v6-00010
-  - patternfly-v5-to-patternfly-v6-patternfly-v6-00020
-  - patternfly-v5-to-patternfly-v6-patternfly-v6-00040
-  - patternfly-v5-to-patternfly-v6-patternfly-v6-00050
-  - patternfly-v5-to-patternfly-v6-patternfly-v6-00160
-  - patternfly-v5-to-patternfly-v6-patternfly-v6-00180
-  - patternfly-v5-to-patternfly-v6-patternfly-v6-00190
-  - patternfly-v5-to-patternfly-v6-patternfly-v6-00200
-  - patternfly-v5-to-patternfly-v6-patternfly-v6-00210
-  - patternfly-v5-to-patternfly-v6-patternfly-v6-00220
-  - patternfly-v5-to-patternfly-v6-promoted-components-00000
-  - patternfly-v5-to-patternfly-v6-removed-components-00000
-  - patternfly-v5-to-patternfly-v6-removed-components-00010
-  - patternfly-v5-to-patternfly-v6-removed-props-00020
-  - patternfly-v5-to-patternfly-v6-removed-props-00030
-  - patternfly-v5-to-patternfly-v6-removed-props-00060
-  - patternfly-v5-to-patternfly-v6-removed-props-00070
-  - patternfly-v5-to-patternfly-v6-removed-props-00080
-  - patternfly-v5-to-patternfly-v6-removed-props-00090
-  - patternfly-v5-to-patternfly-v6-removed-props-00100
-  - patternfly-v5-to-patternfly-v6-renamed-props-00000
-  - patternfly-v5-to-patternfly-v6-renamed-props-00030
-  - patternfly-v5-to-patternfly-v6-renamed-props-00080
-  - patternfly-v5-to-patternfly-v6-toolbar-00040
-  - patternfly-v5-to-patternfly-v6-toolbar-00050
-  - patternfly-v5-to-patternfly-v6-toolbar-00060
-  - patternfly-v5-to-patternfly-v6-toolbar-00070
-  - patternfly-v5-to-patternfly-v6-toolbar-00080
-  - patternfly-v5-to-patternfly-v6-unauthorized-access-00010
 - name: quarkus/springboot
   description: This ruleset gives hints to migrate from SpringBoot devtools to Quarkus
   skipped:
@@ -2132,6 +1929,9 @@
 - name: spring-boot
   description: Ruleset for migration of Spring Boot
   skipped:
+  - spring-boot-2.x-to-3.0-actuator-00010
+  - spring-boot-2.x-to-3.0-actuator-00020
+  - spring-boot-2.x-to-3.0-actuator-00030
   - spring-boot-2.x-to-3.0-batch-00000
   - spring-boot-2.x-to-3.0-batch-00010
   - spring-boot-2.x-to-3.0-batch-00020
@@ -2139,6 +1939,9 @@
   - spring-boot-2.x-to-3.0-core-changes-00010
   - spring-boot-2.x-to-3.0-core-changes-00020
   - spring-boot-2.x-to-3.0-core-changes-00030
+  - spring-boot-2.x-to-3.0-core-changes-00040
+  - spring-boot-2.x-to-3.0-core-changes-00050
+  - spring-boot-2.x-to-3.0-core-changes-00060
   - spring-boot-2.x-to-3.0-datasource-00000
   - spring-boot-2.x-to-3.0-datasource-00010
   - spring-boot-2.x-to-3.0-datasource-00020
@@ -2146,6 +1949,7 @@
   - spring-boot-2.x-to-3.0-datasource-00040
   - spring-boot-2.x-to-3.0-datasource-00050
   - spring-boot-2.x-to-3.0-datasource-00060
+  - spring-boot-2.x-to-3.0-datasource-00070
   - spring-boot-2.x-to-3.0-dependencies-00001
   - spring-boot-2.x-to-3.0-dependencies-00002
   - spring-boot-2.x-to-3.0-dependencies-00003
@@ -2162,6 +1966,12 @@
   - spring-boot-2.x-to-3.0-dependencies-00014
   - spring-boot-2.x-to-3.0-dependencies-00015
   - spring-boot-2.x-to-3.0-dependencies-00016
+  - spring-boot-2.x-to-3.0-dependencies-00020
+  - spring-boot-2.x-to-3.0-dependencies-00021
+  - spring-boot-2.x-to-3.0-micrometer-00010
+  - spring-boot-2.x-to-3.0-micrometer-00020
+  - spring-boot-2.x-to-3.0-micrometer-00030
+  - spring-boot-2.x-to-3.0-micrometer-00040
   - spring-boot-2.x-to-3.0-removals-00010
   - spring-boot-2.x-to-3.0-removals-00020
   - spring-boot-2.x-to-3.0-removals-00030
@@ -2282,8 +2092,13 @@
   - spring-boot-2.x-to-3.0-security-00000
   - spring-boot-2.x-to-3.0-security-00010
   - spring-boot-2.x-to-3.0-session-00000
+  - spring-boot-2.x-to-3.0-session-00010
+  - spring-boot-2.x-to-3.0-session-00020
   - spring-boot-2.x-to-3.0-webapp-changes-00000
   - spring-boot-2.x-to-3.0-webapp-changes-00010
+  - spring-boot-2.x-to-3.0-webapp-changes-00020
+  - spring-boot-2.x-to-3.0-webapp-changes-00030
+  - spring-boot-2.x-to-3.0-webapp-changes-00040
 - name: spring-framework
   description: Ruleset for migration of Spring Framework versions
   skipped:
@@ -2804,10 +2619,12 @@
   - clustering-00000
   - clustering-00001
   - configuration-management-0100
+  - configuration-management-0200
   - configuration-management-0300
   - configuration-management-0400
   - configuration-management-0500
   - configuration-management-technology-usage-0100
+  - configuration-management-technology-usage-0200
   - configuration-management-technology-usage-0300
   - connect-01400
   - connect-01500
@@ -3381,6 +3198,7 @@
   - technology-usage-mvc-03900
   - technology-usage-mvc-04000
   - technology-usage-mvc-04100
+  - technology-usage-mvc-04200
   - technology-usage-mvc-04300
   - technology-usage-mvc-04400
   - technology-usage-mvc-04500
@@ -3399,7 +3217,6 @@
   - technology-usage-mvc-05800
   - technology-usage-mvc-05900
   - technology-usage-mvc-06000
-  - technology-usage-mvc-0x4200
   - technology-usage-security-01000
   - technology-usage-security-01100
   - technology-usage-security-01200


### PR DESCRIPTION
Fixes #734 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved default ruleset discovery for containerless and hybrid analysis — now detects provider-specific ruleset subdirectories (Java, Node.js, .NET) and supports disabling automatic loading of defaults.
* **Tests**
  * Added unit and integration tests covering default ruleset path resolution across providers and analysis modes.
* **Documentation / Data**
  * Updated published ruleset/manifest entries (notably Spring Boot additions and removals across several frameworks), affecting reported migration guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->