### PR TITLE
:sparkles: Remove windows-image-build job from workflow

### DIFF
--- a/.github/workflows/multi-arch-image-build.yaml
+++ b/.github/workflows/multi-arch-image-build.yaml
@@ -30,25 +30,9 @@ jobs:
       registry_username: ${{ secrets.QUAY_PUBLISH_ROBOT }}
       registry_password: ${{ secrets.QUAY_PUBLISH_TOKEN }}
 
-  windows-image-build:
-    runs-on: windows-latest
-    steps:
-    - uses: actions/checkout@main
-    - name: Login to Docker Hub
-      uses: docker/login-action@master
-      with:
-        registry: "quay.io/konveyor"
-        username: ${{ secrets.QUAY_PUBLISH_ROBOT }}
-        password: ${{ secrets.QUAY_PUBLISH_TOKEN }}
-    - name: Build static-report
-      run: |
-        docker build -f ./Dockerfile.windows -t quay.io/konveyor/kantra:$env:tag-windowsservercore-ltsc2022 .
-        docker push quay.io/konveyor/kantra:$env:tag-windowsservercore-ltsc2022
-
   update-manifest:
     needs:
     - image-build
-    - windows-image-build
     runs-on: ubuntu-latest
     steps:
     - name: update manifest


### PR DESCRIPTION
Removed the windows-image-build job from the workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed Windows Docker image build from CI/CD pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->