### PR TITLE
:sparkles: Take rulesets from seed instead of rulesets repo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -86,7 +86,7 @@ RUN chown -R 0:1001 /usr/local/static-report
 COPY --from=builder /workspace/kantra /usr/local/bin/kantra
 COPY --from=builder /workspace/darwin-kantra /usr/local/bin/darwin-kantra
 COPY --from=builder /workspace/windows-kantra /usr/local/bin/windows-kantra
-COPY --from=rulesets /tackle2-seed/resources/rulesets/stable /opt/rulesets
+COPY --from=rulesets /tackle2-seed/resources/rulesets /opt/rulesets
 COPY --from=rulesets /windup-rulesets/rules/rules-reviewed/openrewrite /opt/openrewrite
 COPY --from=static-report /usr/local/static-report /usr/local/static-report
 COPY --from=jaeger-builder /go/bin/all-in-one-linux /usr/local/bin/all-in-one-linux


### PR DESCRIPTION
Fixes https://github.com/konveyor/kantra/issues/692

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the build to source rulesets from a new location, adjusting copy sources accordingly while preserving the overall multi-stage build flow and other provider assets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->