### PR TITLE
:bug: Now we have more providers with default rules

### DIFF
--- a/cmd/analyze.go
+++ b/cmd/analyze.go
@@ -252,12 +252,6 @@ func NewAnalyzeCmd(log logr.Logger) *cobra.Command {
 				log.Info("--run-local set to false. Running analysis in hybrid mode")
 			}
 
-			// default rulesets are only java rules
-			// may want to change this in the future
-			if len(foundProviders) > 0 && len(analyzeCmd.rules) == 0 && !slices.Contains(foundProviders, util.JavaProvider) {
-				return fmt.Errorf("no providers found with default rules. Use --rules option")
-			}
-
 			// alizer does not detect certain files such as xml
 			// in this case, we can first check for a java project
 			// if not found, only start builtin provider in hybrid mode
@@ -606,15 +600,8 @@ func (a *analyzeCommand) validateRulesPath(rulePath string) error {
 }
 
 func (a *analyzeCommand) needDefaultRules() {
-	needDefaultRulesets := false
-	for prov := range a.providersMap {
-		// default rulesets may have been disabled by user
-		if prov == util.JavaProvider && a.enableDefaultRulesets {
-			needDefaultRulesets = true
-			break
-		}
-	}
-	if !needDefaultRulesets {
+	// Only disable default rulesets when there are no providers to analyze.
+	if a.enableDefaultRulesets && len(a.providersMap) == 0 {
 		a.enableDefaultRulesets = false
 	}
 }

--- a/cmd/analyze_test.go
+++ b/cmd/analyze_test.go
@@ -675,13 +675,13 @@ func Test_analyzeCommand_needDefaultRules(t *testing.T) {
 			expectedEnableDefaultRulesets: false,
 		},
 		{
-			name:                         "non-java providers only should disable default rulesets",
+			name:                         "multiple providers with enabled rulesets should keep rulesets enabled",
 			initialEnableDefaultRulesets: true,
 			providersMap: map[string]ProviderInit{
 				util.PythonProvider: {},
 				util.GoProvider:     {},
 			},
-			expectedEnableDefaultRulesets: false,
+			expectedEnableDefaultRulesets: true,
 		},
 		{
 			name:                         "mixed providers including java with enabled rulesets should keep rulesets enabled",
@@ -704,36 +704,36 @@ func Test_analyzeCommand_needDefaultRules(t *testing.T) {
 			expectedEnableDefaultRulesets: false,
 		},
 		{
-			name:                         "python provider only should disable default rulesets",
+			name:                         "python provider only with enabled rulesets should keep rulesets enabled",
 			initialEnableDefaultRulesets: true,
 			providersMap: map[string]ProviderInit{
 				util.PythonProvider: {},
 			},
-			expectedEnableDefaultRulesets: false,
+			expectedEnableDefaultRulesets: true,
 		},
 		{
-			name:                         "go provider only should disable default rulesets",
+			name:                         "go provider only with enabled rulesets should keep rulesets enabled",
 			initialEnableDefaultRulesets: true,
 			providersMap: map[string]ProviderInit{
 				util.GoProvider: {},
 			},
-			expectedEnableDefaultRulesets: false,
+			expectedEnableDefaultRulesets: true,
 		},
 		{
-			name:                         "nodejs provider only should disable default rulesets",
+			name:                         "nodejs provider only with enabled rulesets should keep rulesets enabled",
 			initialEnableDefaultRulesets: true,
 			providersMap: map[string]ProviderInit{
 				util.NodeJSProvider: {},
 			},
-			expectedEnableDefaultRulesets: false,
+			expectedEnableDefaultRulesets: true,
 		},
 		{
-			name:                         "dotnet provider only should disable default rulesets",
+			name:                         "dotnet provider only with enabled rulesets should keep rulesets enabled",
 			initialEnableDefaultRulesets: true,
 			providersMap: map[string]ProviderInit{
 				util.CsharpProvider: {},
 			},
-			expectedEnableDefaultRulesets: false,
+			expectedEnableDefaultRulesets: true,
 		},
 		{
 			name:                         "already disabled rulesets with non-java providers should remain disabled",
@@ -1243,7 +1243,7 @@ func Test_analyzeCommand_needDefaultRules_StateChanges(t *testing.T) {
 		expectedOnlyChanged []string
 	}{
 		{
-			name: "should only modify enableDefaultRulesets when disabling",
+			name: "should only modify enableDefaultRulesets when no providers",
 			initialState: &analyzeCommand{
 				enableDefaultRulesets: true,
 				output:                "/test/output",
@@ -1251,7 +1251,7 @@ func Test_analyzeCommand_needDefaultRules_StateChanges(t *testing.T) {
 				sources:               []string{"test"},
 				AnalyzeCommandContext: AnalyzeCommandContext{
 					log:          log,
-					providersMap: map[string]ProviderInit{util.PythonProvider: {}},
+					providersMap: map[string]ProviderInit{},
 				},
 			},
 			expectedOnlyChanged: []string{"enableDefaultRulesets"},
@@ -1350,48 +1350,33 @@ func Test_analyzeCommand_needDefaultRules_EdgeCases(t *testing.T) {
 			expected: false,
 		},
 		{
-			name: "empty string key in providersMap should not match java",
+			name: "non-empty providersMap keeps rulesets enabled",
 			setup: func() *analyzeCommand {
 				return &analyzeCommand{
 					enableDefaultRulesets: true,
 					AnalyzeCommandContext: AnalyzeCommandContext{
 						providersMap: map[string]ProviderInit{
-							"": {},
+							util.GoProvider: {},
 						},
 					},
 				}
 			},
-			expected: false,
+			expected: true,
 		},
 		{
-			name: "whitespace in provider name should not match java",
+			name: "providersMap with multiple providers keeps rulesets enabled",
 			setup: func() *analyzeCommand {
 				return &analyzeCommand{
 					enableDefaultRulesets: true,
 					AnalyzeCommandContext: AnalyzeCommandContext{
 						providersMap: map[string]ProviderInit{
-							" java ": {},
+							util.JavaProvider:   {},
+							util.PythonProvider: {},
 						},
 					},
 				}
 			},
-			expected: false,
-		},
-		{
-			name: "java with different casing should not match",
-			setup: func() *analyzeCommand {
-				return &analyzeCommand{
-					enableDefaultRulesets: true,
-					AnalyzeCommandContext: AnalyzeCommandContext{
-						providersMap: map[string]ProviderInit{
-							"JAVA": {},
-							"Java": {},
-							"jAvA": {},
-						},
-					},
-				}
-			},
-			expected: false,
+			expected: true,
 		},
 	}
 


### PR DESCRIPTION
Fixes #754 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where default rulesets were incorrectly disabled when using multiple providers. Default rulesets are now properly preserved and enabled in all multi-provider scenarios, ensuring consistent rule application, reducing configuration complexity, and improving overall compatibility and reliability across different provider combinations and analysis workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->