### PR TITLE
:sparkles: Move RUN_LOCAL env var to --run-local flag on test command

### DIFF
--- a/cmd/settings.go
+++ b/cmd/settings.go
@@ -29,7 +29,6 @@ type Config struct {
 	RootCommandName      string `env:"CMD_NAME" default:"kantra"`
 	ContainerBinary      string `env:"CONTAINER_TOOL" default:"/usr/bin/podman"`
 	RunnerImage          string `env:"RUNNER_IMG" default:"quay.io/konveyor/kantra"`
-	RunLocal             bool   `env:"RUN_LOCAL"`
 	JvmMaxMem            string `env:"JVM_MAX_MEM" default:""`
 	JavaProviderImage    string `env:"JAVA_PROVIDER_IMG" default:"quay.io/konveyor/java-external-provider:latest"`
 	GenericProviderImage string `env:"GENERIC_PROVIDER_IMG" default:"quay.io/konveyor/generic-external-provider:latest"`

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -12,6 +12,7 @@ type testCommand struct {
 	testFilterString     string
 	baseProviderSettings string
 	prune                bool
+	runLocal             bool
 }
 
 func NewTestCommand(log logr.Logger) *cobra.Command {
@@ -35,7 +36,7 @@ func NewTestCommand(log logr.Logger) *cobra.Command {
 				return nil
 			}
 			results, err := testing.NewRunner().Run(tests, testing.TestOptions{
-				RunLocal:         Settings.RunLocal,
+				RunLocal:         testCmd.runLocal,
 				ContainerImage:   Settings.RunnerImage,
 				ContainerToolBin: Settings.ContainerBinary,
 				ProgressPrinter:  testing.PrintProgress,
@@ -54,5 +55,6 @@ func NewTestCommand(log logr.Logger) *cobra.Command {
 	testCobraCommand.Flags().StringVarP(&testCmd.testFilterString, "test-filter", "t", "", "filter tests / testcases by their names")
 	testCobraCommand.Flags().StringVarP(&testCmd.baseProviderSettings, "base-provider-settings", "b", "", "path to a provider settings file the runner will use as base")
 	testCobraCommand.Flags().BoolVarP(&testCmd.prune, "prune", "p", false, "whether to prune after the execution; defaults to false")
+	testCobraCommand.Flags().BoolVar(&testCmd.runLocal, "run-local", true, "run tests in containerless mode")
 	return testCobraCommand
 }

--- a/cmd/test_cmd_test.go
+++ b/cmd/test_cmd_test.go
@@ -50,8 +50,9 @@ func TestTestCommand_Flags(t *testing.T) {
 	// Check for expected flags
 	expectedFlags := []string{
 		"test-filter",
-		"base-provider-settings", 
+		"base-provider-settings",
 		"prune",
+		"run-local",
 	}
 	
 	for _, flagName := range expectedFlags {
@@ -218,6 +219,14 @@ func TestTestCommand_FlagValues(t *testing.T) {
 			t.Errorf("Expected prune flag default to be 'false', got '%s'", pruneFlag.DefValue)
 		}
 	}
+
+	// Test run-local flag
+	runLocalFlag := flags.Lookup("run-local")
+	if runLocalFlag != nil {
+		if runLocalFlag.DefValue != "true" {
+			t.Errorf("Expected run-local flag default to be 'true', got '%s'", runLocalFlag.DefValue)
+		}
+	}
 }
 
 func TestTestCommand_ExecuteWithArgs(t *testing.T) {
@@ -243,6 +252,10 @@ func TestTestCommand_ExecuteWithArgs(t *testing.T) {
 		{
 			name: "with base-provider-settings flag",
 			args: []string{"--base-provider-settings", "settings.yaml"},
+		},
+		{
+			name: "with run-local flag",
+			args: []string{"--run-local=false"},
 		},
 		{
 			name: "with multiple flags",


### PR DESCRIPTION
## Summary

- Adds a `--run-local` CLI flag to the `kantra test` subcommand (defaults to `true`), replacing the `RUN_LOCAL` environment variable
- Aligns the test command's interface with how `kantra analyze` already handles the `--run-local` option
- Removes the now-unused `RunLocal` field from the global `Config` struct

## Test plan

- [x] `go build ./...` compiles cleanly
- [x] `go test ./cmd/...` passes (including updated flag tests)
- [ ] Manual: `kantra test --run-local <path>` runs tests in containerless mode
- [ ] Manual: `kantra test --run-local=false <path>` runs tests in container mode

Closes #684

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Test command now supports a --run-local flag for containerless test execution (enabled by default).
* **Refactor**
  * The environment-based toggle for running tests locally has been removed from global configuration and is now controlled per-command via the new flag.
* **Tests**
  * Test coverage expanded to validate the new run-local flag and its behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->