### PR TITLE
:bug: Fix kantra test treating absolute dataPath as relative

### DIFF
--- a/docs/testrunner.md
+++ b/docs/testrunner.md
@@ -50,9 +50,7 @@ tests:
   [...]
 ```
 
-_name_ is the name of the provider to which the config applies to, and _dataPath_ is the relative path to the test data to be used when testing rules for that provider.
-
-> Note that _dataPath_ must be relative to the directory in which tests file exists.
+_name_ is the name of the provider to which the config applies to, and _dataPath_ is the path to the test data to be used when testing rules for that provider. It can be a relative path (resolved relative to the directory in which the tests file exists) or an absolute path.
 
 If all tests under a _ruleset_ share values of _providers_ field (e.g. they use common data directory in all tests for a given provider), this config can also be defined at ruleset level under a special file `testing-config.yaml`. In that case, the config present in this file will apply to all tests in that directory. A more specific config for a certain file can still be defined in the tests file. In that case, values in the tests file will take precedance over values at the _ruleset_ level.
 

--- a/pkg/testing/runner.go
+++ b/pkg/testing/runner.go
@@ -116,7 +116,7 @@ func (r defaultRunner) Run(testFiles []TestsFile, opts TestOptions) ([]Result, e
 			// For the moment, use the first provider's dataPath (relative to test file).
 			dataPath := ""
 			if len(testsFile.Providers) > 0 && testsFile.Providers[0].DataPath != "" {
-				dataPath = filepath.Join(filepath.Dir(testsFile.Path), filepath.Clean(testsFile.Providers[0].DataPath))
+				dataPath = resolveDataPath(testsFile.Path, testsFile.Providers[0].DataPath)
 			}
 
 			reproducerCmd, err := runWithEnvironment(
@@ -415,6 +415,15 @@ func ensureRules(rulesPath string, tempDirPath string, group []Test) error {
 		return fmt.Errorf("failed writing rules file - %w", err)
 	}
 	return nil
+}
+
+// resolveDataPath resolves a dataPath relative to the test file's directory,
+// or returns it as-is if it is already an absolute path.
+func resolveDataPath(testsFilePath string, dataPath string) string {
+	if filepath.IsAbs(dataPath) {
+		return dataPath
+	}
+	return filepath.Join(filepath.Dir(testsFilePath), filepath.Clean(dataPath))
 }
 
 func groupTestsByAnalysisParams(tests []Test) [][]Test {

--- a/pkg/testing/runner_test.go
+++ b/pkg/testing/runner_test.go
@@ -5,6 +5,49 @@ import (
 	"testing"
 )
 
+func Test_resolveDataPath(t *testing.T) {
+	tests := []struct {
+		name          string
+		testsFilePath string
+		dataPath      string
+		want          string
+	}{
+		{
+			name:          "relative path is joined with test file dir",
+			testsFilePath: "/home/user/tests/my.test.yaml",
+			dataPath:      "./test-data/python",
+			want:          "/home/user/tests/test-data/python",
+		},
+		{
+			name:          "relative path without dot prefix",
+			testsFilePath: "/home/user/tests/my.test.yaml",
+			dataPath:      "test-data/python",
+			want:          "/home/user/tests/test-data/python",
+		},
+		{
+			name:          "absolute path is returned as-is",
+			testsFilePath: "/home/user/tests/my.test.yaml",
+			dataPath:      "/opt/data/examples/nodejs",
+			want:          "/opt/data/examples/nodejs",
+		},
+		{
+			name:          "absolute path is not prepended with test file dir",
+			testsFilePath: "/home/user/tests/my.test.yaml",
+			dataPath:      "/home/other/git/analyzer-lsp/examples/nodejs",
+			want:          "/home/other/git/analyzer-lsp/examples/nodejs",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := resolveDataPath(tt.testsFilePath, tt.dataPath)
+			if got != tt.want {
+				t.Errorf("resolveDataPath() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+
 // ENV_RUN_LOCAL enables the runner to run analysis locally instead of a container
 // this must be set in CI containers to make sure we are not launching containers
 const RUNNER_IMG = "RUNNER_IMG"


### PR DESCRIPTION
## Summary

- Extracts a `resolveDataPath()` helper that checks `filepath.IsAbs()` before joining paths
- Fixes both local (containerless) and container execution modes
- Adds unit tests covering relative and absolute `dataPath` values
- Updates documentation to reflect that `dataPath` supports absolute paths

## Root Cause

`filepath.Join(dir, absolutePath)` in Go does **not** preserve the absolute path — it concatenates them, producing invalid paths like `/testdir/home/user/data`.

## Test plan

- [x] `go build ./...` compiles cleanly
- [x] `go test ./pkg/testing/...` — all 26 tests pass including new `Test_resolveDataPath`
- [x] Manual: `kantra test` with a relative `dataPath` works as before (PASSED)
- [x] Manual: `kantra test` with an absolute `dataPath` now resolves correctly (PASSED)
- [x] Verified unfixed build fails with absolute `dataPath` (exit status 1)

Fixes #688

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * dataPath now accepts both relative and absolute paths; relative paths are resolved against the test file directory.

* **Documentation**
  * Clarified test runner docs to explain dataPath behavior and resolution rules.

* **Tests**
  * Added unit tests covering relative and absolute dataPath resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->