### PR TITLE
:bug: Remove old default providers check

### DIFF
--- a/cmd/analyze/analyze.go
+++ b/cmd/analyze/analyze.go
@@ -201,10 +201,6 @@ func NewAnalyzeCmd(log logr.Logger) *cobra.Command {
 
 			// For hybrid mode with non-Java providers: check default rules availability
 			if mode == kantraProvider.ModeNetwork {
-				if len(foundProviders) > 0 && len(analyzeCmd.rules) == 0 && !slices.Contains(foundProviders, util.JavaProvider) {
-					return fmt.Errorf("no providers found with default rules. Use --rules option")
-				}
-
 				// alizer does not detect certain files such as xml
 				// in this case, we can first check for a java project
 				// if not found, only start builtin provider


### PR DESCRIPTION
Old check in hybrid mode that assumes default provider is only java. This code is weird; there's an identical check 5 lines later but it knows that csharp and nodejs have default rules.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified provider detection and rules validation logic in hybrid mode for improved efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->