### PR TITLE
Get sources/targets from cli over profile

### DIFF
--- a/cmd/analyze/analyze.go
+++ b/cmd/analyze/analyze.go
@@ -233,7 +233,7 @@ func NewAnalyzeCmd(log logr.Logger) *cobra.Command {
 			// Run unified analysis pipeline
 			cmdCtx, cancelFunc := context.WithCancel(ctx)
 			defer cancelFunc()
-			err = analyzeCmd.runAnalysis(cmdCtx, mode, foundProviders)
+			err = analyzeCmd.runAnalysis(cmdCtx, cmd, mode, foundProviders)
 			if err != nil {
 				log.Error(err, "analysis failed")
 				return err

--- a/cmd/analyze/analyze_test.go
+++ b/cmd/analyze/analyze_test.go
@@ -453,10 +453,22 @@ func contains(s, substr string) bool {
 	return strings.Contains(s, substr)
 }
 
+// makeLabelSelectorCLICommand returns a command whose --label-selector flag is marked Changed,
+// matching a real user invocation of -l / --label-selector.
+func makeLabelSelectorCLICommand(value string) *cobra.Command {
+	cmd := &cobra.Command{}
+	cmd.Flags().StringP("label-selector", "l", "", "")
+	_ = cmd.Flags().Set("label-selector", value)
+	cmd.Flags().Lookup("label-selector").Changed = true
+	return cmd
+}
+
 func Test_analyzeCommand_getLabelSelectorArgs(t *testing.T) {
 	tests := []struct {
 		name          string
 		labelSelector string
+		profilePath   string
+		cmd           *cobra.Command
 		sources       []string
 		targets       []string
 		want          string
@@ -506,7 +518,21 @@ func Test_analyzeCommand_getLabelSelectorArgs(t *testing.T) {
 			targets:       []string{"t1", "t2"},
 			sources:       []string{"t1", "t2"},
 			labelSelector: "example.io/target=foo",
+			cmd:           makeLabelSelectorCLICommand("example.io/target=foo"),
 			want:          "example.io/target=foo",
+		},
+		{
+			name:          "CLI target merges with profile labelSelector via AND",
+			labelSelector: "(hibernate)",
+			profilePath:   "/app/.konveyor/profiles/p/profile.yaml",
+			targets:       []string{"cloud-readiness"},
+			want:          "((konveyor.io/target=cloud-readiness) || (discovery)) && ((hibernate))",
+		},
+		{
+			name:          "without profile, target only uses CLI expression (no AND with labelSelector)",
+			labelSelector: "(hibernate)",
+			targets:       []string{"cloud-readiness"},
+			want:          "(konveyor.io/target=cloud-readiness) || (discovery)",
 		},
 		{
 			name:          "multiple sources & targets specified, OR them within each other, AND result with catch-all source label, finally OR with default labels",
@@ -522,8 +548,9 @@ func Test_analyzeCommand_getLabelSelectorArgs(t *testing.T) {
 				sources:       tt.sources,
 				targets:       tt.targets,
 				labelSelector: tt.labelSelector,
+				profilePath:   tt.profilePath,
 			}
-			if got := a.getLabelSelector(); !reflect.DeepEqual(got, tt.want) {
+			if got := a.getLabelSelector(tt.cmd); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("analyzeCommand.getLabelSelectorArgs() = %v, want %v", got, tt.want)
 			}
 		})

--- a/cmd/analyze/provider_config.go
+++ b/cmd/analyze/provider_config.go
@@ -8,14 +8,40 @@ import (
 
 	outputv1 "github.com/konveyor/analyzer-lsp/output/v1/konveyor"
 	"github.com/konveyor/analyzer-lsp/provider"
+	"github.com/spf13/cobra"
 )
 
-func (a *analyzeCommand) getLabelSelector() string {
+func labelSelectorSetFromCLI(cmd *cobra.Command) bool {
+	if cmd == nil {
+		return false
+	}
+	f := cmd.Flags().Lookup("label-selector")
+	if f == nil {
+		return false
+	}
+	return f.Changed
+}
+
+func (a *analyzeCommand) getLabelSelector(cmd *cobra.Command) string {
+	if labelSelectorSetFromCLI(cmd) && a.labelSelector != "" {
+		return a.labelSelector
+	}
+	hasSourceOrTarget := len(a.sources) > 0 || len(a.targets) > 0
+	if hasSourceOrTarget {
+		cliExpr := a.labelSelectorFromSourcesTargets()
+		if a.profilePath != "" && a.labelSelector != "" && !labelSelectorSetFromCLI(cmd) {
+			return fmt.Sprintf("(%s) && (%s)", cliExpr, a.labelSelector)
+		}
+		return cliExpr
+	}
 	if a.labelSelector != "" {
 		return a.labelSelector
 	}
-	if (a.sources == nil || len(a.sources) == 0) &&
-		(a.targets == nil || len(a.targets) == 0) {
+	return ""
+}
+
+func (a *analyzeCommand) labelSelectorFromSourcesTargets() string {
+	if len(a.sources) == 0 && len(a.targets) == 0 {
 		return ""
 	}
 	// default labels are applied everytime either a source or target is specified
@@ -43,12 +69,11 @@ func (a *analyzeCommand) getLabelSelector() string {
 			// when both targets and sources are present, AND them
 			return fmt.Sprintf("(%s && %s) || (%s)",
 				targetExpr, sourceExpr, strings.Join(defaultLabels, " || "))
-		} else {
-			// when target is specified, but source is not
-			// return target expression OR'd with default labels
-			return fmt.Sprintf("%s || (%s)",
-				targetExpr, strings.Join(defaultLabels, " || "))
 		}
+		// when target is specified, but source is not
+		// return target expression OR'd with default labels
+		return fmt.Sprintf("%s || (%s)",
+			targetExpr, strings.Join(defaultLabels, " || "))
 	}
 	if sourceExpr != "" {
 		// when only source is specified, OR them all

--- a/cmd/analyze/run.go
+++ b/cmd/analyze/run.go
@@ -17,6 +17,7 @@ import (
 	"github.com/konveyor/analyzer-lsp/provider"
 	"github.com/konveyor/analyzer-lsp/tracing"
 	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v2"
 )
 
@@ -63,7 +64,7 @@ func (a *analyzeCommand) setProxyEnvironment() {
 	}
 }
 
-func (a *analyzeCommand) runAnalysis(ctx context.Context, mode kantraprovider.ExecutionMode, foundProviders []string) error {
+func (a *analyzeCommand) runAnalysis(ctx context.Context, cmd *cobra.Command, mode kantraprovider.ExecutionMode, foundProviders []string) error {
 	restoreStderr := util.InstallStderrFilter()
 	defer restoreStderr()
 
@@ -197,7 +198,7 @@ func (a *analyzeCommand) runAnalysis(ctx context.Context, mode kantraprovider.Ex
 	}
 
 	// --- Label selectors ---
-	labelSelector := a.getLabelSelector()
+	labelSelector := a.getLabelSelector(cmd)
 	depLabelSelector := ""
 	if !a.analyzeKnownLibraries {
 		depLabelSelector = fmt.Sprintf("!%v=open-source", provider.DepSourceLabel)

--- a/pkg/profile/profile.go
+++ b/pkg/profile/profile.go
@@ -120,8 +120,15 @@ func SetSettingsFromProfile(path string, cmd *cobra.Command, settings *ProfileSe
 	if !cmd.Flags().Lookup("incident-selector").Changed {
 		settings.IncidentSelector = buildIncidentSelector(profile.Scope.Packages)
 	}
+
+	sourceSet := cmd.Flags().Lookup("source") != nil && cmd.Flags().Lookup("source").Changed
+	targetSet := cmd.Flags().Lookup("target") != nil && cmd.Flags().Lookup("target").Changed
 	if !cmd.Flags().Lookup("label-selector").Changed {
-		settings.LabelSelector = buildLabelSelector(profile.Rules.Labels)
+		labels := profile.Rules.Labels
+		if sourceSet || targetSet {
+			labels = filterKonveyorSourceTargetLabels(labels, sourceSet, targetSet)
+		}
+		settings.LabelSelector = buildLabelSelector(labels)
 	}
 	// prioritize user-set enable-default-rulesets
 	if cmd.Flags().Lookup("enable-default-rulesets") != nil && cmd.Flags().Lookup("enable-default-rulesets").Changed {
@@ -133,8 +140,6 @@ func SetSettingsFromProfile(path string, cmd *cobra.Command, settings *ProfileSe
 
 		// use default rulesets if default sources/targets are used
 	} else {
-		targetSet := cmd.Flags().Lookup("target") != nil && cmd.Flags().Lookup("target").Changed
-		sourceSet := cmd.Flags().Lookup("source") != nil && cmd.Flags().Lookup("source").Changed
 		hasDefaultLabels := profileHasDefaultKonveyorLabels(profile)
 		settings.EnableDefaultRulesets = targetSet || sourceSet || hasDefaultLabels
 	}
@@ -152,6 +157,43 @@ func SetSettingsFromProfile(path string, cmd *cobra.Command, settings *ProfileSe
 	}
 
 	return nil
+}
+
+func filterKonveyorSourceTargetLabels(labels LabelSelector, sourceSet, targetSet bool) LabelSelector {
+	filtered := LabelSelector{
+		Included: make([]string, 0, len(labels.Included)),
+		Excluded: make([]string, 0, len(labels.Excluded)),
+	}
+	for _, label := range labels.Included {
+		if shouldFilterKonveyorLabel(label, sourceSet, targetSet) {
+			continue
+		}
+		filtered.Included = append(filtered.Included, label)
+	}
+	for _, label := range labels.Excluded {
+		if shouldFilterKonveyorLabel(label, sourceSet, targetSet) {
+			continue
+		}
+		filtered.Excluded = append(filtered.Excluded, label)
+	}
+	return filtered
+}
+
+func shouldFilterKonveyorLabel(label string, sourceSet, targetSet bool) bool {
+	label = strings.TrimSpace(label)
+	if sourceSet {
+		sourcePrefix := outputv1.SourceTechnologyLabel + "="
+		if label == outputv1.SourceTechnologyLabel || strings.HasPrefix(label, sourcePrefix) {
+			return true
+		}
+	}
+	if targetSet {
+		targetPrefix := outputv1.TargetTechnologyLabel + "="
+		if label == outputv1.TargetTechnologyLabel || strings.HasPrefix(label, targetPrefix) {
+			return true
+		}
+	}
+	return false
 }
 
 func buildIncidentSelector(packages PackageSelector) string {

--- a/pkg/profile/profile_test.go
+++ b/pkg/profile/profile_test.go
@@ -694,6 +694,97 @@ func TestSetSettingsFromProfile_EnableDefaultRulesets(t *testing.T) {
 	}
 }
 
+func TestSetSettingsFromProfile_SourceTargetOverrideProfileKonveyorLabels(t *testing.T) {
+	makeProfileWithKonveyorPath := func(t *testing.T, profileYAML string) (profilePath string, cleanup func()) {
+		t.Helper()
+		tmpDir, err := os.MkdirTemp("", "test-profile-")
+		if err != nil {
+			t.Fatalf("MkdirTemp: %v", err)
+		}
+		konveyorDir := filepath.Join(tmpDir, "app", ".konveyor", "profiles", "p")
+		if err := os.MkdirAll(konveyorDir, 0755); err != nil {
+			os.RemoveAll(tmpDir)
+			t.Fatalf("MkdirAll: %v", err)
+		}
+		profilePath = filepath.Join(konveyorDir, "profile.yaml")
+		if err := os.WriteFile(profilePath, []byte(profileYAML), 0644); err != nil {
+			os.RemoveAll(tmpDir)
+			t.Fatalf("WriteFile: %v", err)
+		}
+		return profilePath, func() { os.RemoveAll(tmpDir) }
+	}
+
+	makeCmd := func() *cobra.Command {
+		cmd := &cobra.Command{}
+		cmd.Flags().String("input", "", "")
+		cmd.Flags().String("mode", "", "")
+		cmd.Flags().Bool("analyze-known-libraries", false, "")
+		cmd.Flags().String("incident-selector", "", "")
+		cmd.Flags().String("label-selector", "", "")
+		cmd.Flags().StringSlice("rules", nil, "")
+		cmd.Flags().Bool("enable-default-rulesets", true, "")
+		cmd.Flags().StringArray("source", []string{}, "")
+		cmd.Flags().StringArray("target", []string{}, "")
+		return cmd
+	}
+
+	t.Run("target flag removes profile konveyor target labels", func(t *testing.T) {
+		profilePath, cleanup := makeProfileWithKonveyorPath(t, `
+mode: {}
+rules:
+  labels:
+    included:
+      - "konveyor.io/target=eap7"
+      - "konveyor.io/target=eap8"
+      - "hibernate"
+`)
+		defer cleanup()
+
+		cmd := makeCmd()
+		_ = cmd.Flags().Set("target", "eap9")
+		cmd.Flags().Lookup("target").Changed = true
+
+		settings := &ProfileSettings{EnableDefaultRulesets: true}
+		if err := SetSettingsFromProfile(profilePath, cmd, settings); err != nil {
+			t.Fatalf("SetSettingsFromProfile: %v", err)
+		}
+		if settings.LabelSelector != "(hibernate)" {
+			t.Fatalf("LabelSelector = %q, want %q", settings.LabelSelector, "(hibernate)")
+		}
+	})
+
+	t.Run("source and target flags remove all profile konveyor source/target labels", func(t *testing.T) {
+		profilePath, cleanup := makeProfileWithKonveyorPath(t, `
+mode: {}
+rules:
+  labels:
+    included:
+      - "konveyor.io/source=weblogic"
+      - "konveyor.io/target=eap7"
+      - "configuration"
+    excluded:
+      - "konveyor.io/source=springboot"
+      - "konveyor.io/target=eap8"
+      - "deprecated"
+`)
+		defer cleanup()
+
+		cmd := makeCmd()
+		_ = cmd.Flags().Set("source", "quarkus")
+		_ = cmd.Flags().Set("target", "eap9")
+		cmd.Flags().Lookup("source").Changed = true
+		cmd.Flags().Lookup("target").Changed = true
+
+		settings := &ProfileSettings{EnableDefaultRulesets: true}
+		if err := SetSettingsFromProfile(profilePath, cmd, settings); err != nil {
+			t.Fatalf("SetSettingsFromProfile: %v", err)
+		}
+		if settings.LabelSelector != "(configuration) && !deprecated" {
+			t.Fatalf("LabelSelector = %q, want %q", settings.LabelSelector, "(configuration) && !deprecated")
+		}
+	})
+}
+
 func TestGetRulesInProfile(t *testing.T) {
 	tests := []struct {
 		name       string


### PR DESCRIPTION
Fixes #774 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced CLI flag handling for the analyze command: source, target, and label-selector flags now properly take precedence over profile settings when explicitly provided, with improved label filtering when combining CLI flags with profiles.

* **Tests**
  * Added test coverage validating correct label selector behavior when source and target CLI flags are combined with profile settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->