### PR TITLE
Add Java provider binaries to release artifacts

### DIFF
--- a/.github/workflows/release-artifacts.yaml
+++ b/.github/workflows/release-artifacts.yaml
@@ -41,6 +41,9 @@ jobs:
         podman cp kantra-download:/usr/local/bin/kantra . && zip kantra.linux.${{ matrix.arch }}.zip kantra
         podman cp kantra-download:/usr/local/bin/darwin-kantra . && zip kantra.darwin.${{ matrix.arch }}.zip darwin-kantra
         podman cp kantra-download:/usr/local/bin/windows-kantra windows-kantra.exe && zip kantra.windows.${{ matrix.arch }}.zip windows-kantra.exe
+        podman cp kantra-download:/usr/local/bin/java-external-provider . && zip kantra.linux.${{ matrix.arch }}.zip java-external-provider
+        podman cp kantra-download:/usr/local/bin/darwin-java-external-provider . && zip kantra.darwin.${{ matrix.arch }}.zip darwin-java-external-provider
+        podman cp kantra-download:/usr/local/bin/windows-java-external-provider.exe . && zip kantra.windows.${{ matrix.arch }}.zip windows-java-external-provider.exe
 
     - name: Extract containerless reqs
       run: |


### PR DESCRIPTION
Relies on https://github.com/konveyor/analyzer-lsp/pull/1141 

Fixes #784 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added `java-external-provider` binary to release artifacts for all supported platforms (Linux, macOS, and Windows).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->