### PR TITLE
Add --run-local to test cmd

### DIFF
--- a/cmd/test.go
+++ b/cmd/test.go
@@ -12,6 +12,7 @@ import (
 type testCommand struct {
 	testFilterString string
 	prune            bool
+	runLocal         bool
 }
 
 func NewTestCommand(log logr.Logger) *cobra.Command {
@@ -35,6 +36,7 @@ func NewTestCommand(log logr.Logger) *cobra.Command {
 				return nil
 			}
 			results, err := testing.NewRunner().Run(tests, testing.TestOptions{
+				RunLocal:        testCmd.runLocal,
 				ContainerBinary: settings.Settings.ContainerBinary,
 				ProviderImages: map[string]string{
 					"java":   settings.Settings.JavaProviderImage,
@@ -60,5 +62,6 @@ func NewTestCommand(log logr.Logger) *cobra.Command {
 	}
 	testCobraCommand.Flags().StringVarP(&testCmd.testFilterString, "test-filter", "t", "", "filter tests / testcases by their names")
 	testCobraCommand.Flags().BoolVarP(&testCmd.prune, "prune", "p", false, "whether to prune after the execution; defaults to false")
+	testCobraCommand.Flags().BoolVar(&testCmd.runLocal, "run-local", true, "run tests in containerless mode")
 	return testCobraCommand
 }

--- a/cmd/test_cmd_test.go
+++ b/cmd/test_cmd_test.go
@@ -51,6 +51,7 @@ func TestTestCommand_Flags(t *testing.T) {
 	expectedFlags := []string{
 		"test-filter",
 		"prune",
+		"run-local",
 	}
 
 	for _, flagName := range expectedFlags {
@@ -207,6 +208,13 @@ func TestTestCommand_FlagValues(t *testing.T) {
 	if pruneFlag != nil {
 		if pruneFlag.DefValue != "false" {
 			t.Errorf("Expected prune flag default to be 'false', got '%s'", pruneFlag.DefValue)
+		}
+	}
+
+	runLocalFlag := flags.Lookup("run-local")
+	if runLocalFlag != nil {
+		if runLocalFlag.DefValue != "true" {
+			t.Errorf("Expected run-local flag default to be 'true', got '%s'", runLocalFlag.DefValue)
 		}
 	}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new `--run-local` flag for the test command, enabling containerless test execution in a local environment. This flag is enabled by default, providing an easy way to run tests without external container infrastructure dependencies.

* **Tests**
  * Expanded test coverage for the new `--run-local` flag, verifying its presence and default enabled state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->