### PR TITLE
Remove Windows build

### DIFF
--- a/.github/workflows/multi-arch-image-build.yaml
+++ b/.github/workflows/multi-arch-image-build.yaml
@@ -30,25 +30,10 @@ jobs:
       registry_username: ${{ secrets.QUAY_PUBLISH_ROBOT }}
       registry_password: ${{ secrets.QUAY_PUBLISH_TOKEN }}
 
-  windows-image-build:
-    runs-on: windows-latest
-    steps:
-    - uses: actions/checkout@main
-    - name: Login to Docker Hub
-      uses: docker/login-action@master
-      with:
-        registry: "quay.io/konveyor"
-        username: ${{ secrets.QUAY_PUBLISH_ROBOT }}
-        password: ${{ secrets.QUAY_PUBLISH_TOKEN }}
-    - name: Build static-report
-      run: |
-        docker build -f ./Dockerfile.windows -t quay.io/konveyor/kantra:$env:tag-windowsservercore-ltsc2022 .
-        docker push quay.io/konveyor/kantra:$env:tag-windowsservercore-ltsc2022
 
   update-manifest:
     needs:
     - image-build
-    - windows-image-build
     runs-on: ubuntu-latest
     steps:
     - name: update manifest


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed Windows image build from the automated build workflow. The manifest update process now depends only on the standard image build, streamlining the pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->