### PR TITLE
Clean java-project dir after binary analysis

### DIFF
--- a/pkg/provider/env_local.go
+++ b/pkg/provider/env_local.go
@@ -23,6 +23,8 @@ const (
 	fernflowerJar     = "fernflower.jar"
 )
 
+const javaBinaryProjectDirName = "java-project"
+
 // Eclipse language server temporary directories created in the working
 // directory during Java analysis. Cleaned up by Stop.
 var eclipseLSDirs = []string{
@@ -176,7 +178,35 @@ func (e *localEnvironment) Stop(ctx context.Context) error {
 			// continue cleanup even if one fails
 		}
 	}
+	cleanLocalJavaBinaryProjectDirs(e.log, e.cfg.Input, e.cfg.IsFileInput)
 	return nil
+}
+
+func cleanLocalJavaBinaryProjectDirs(log logr.Logger, input string, isFileInput bool) {
+	if !isFileInput {
+		return
+	}
+	parent := filepath.Dir(input)
+	entries, err := os.ReadDir(parent)
+	if err != nil {
+		log.V(1).Info("skipping java-project cleanup", "err", err)
+		return
+	}
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if name != javaBinaryProjectDirName {
+			continue
+		}
+		full := filepath.Join(parent, name)
+		if err := os.RemoveAll(full); err != nil {
+			log.Error(err, "failed to remove decompiled java project directory")
+			continue
+		}
+
+	}
 }
 
 // ProviderConfigs returns ModeLocal provider configurations.

--- a/pkg/provider/env_local_test.go
+++ b/pkg/provider/env_local_test.go
@@ -177,3 +177,44 @@ func TestLocalEnvironment_Stop_CleansUpEclipseDirs(t *testing.T) {
 	err := env.Stop(context.Background())
 	require.NoError(t, err)
 }
+
+func TestCleanLocalJavaBinaryProjectDirs(t *testing.T) {
+	logger := getTestLogger()
+
+	t.Run("removes java-project and java-project-suffix beside binary", func(t *testing.T) {
+		tmp := t.TempDir()
+		bin := filepath.Join(tmp, "app.war")
+		require.NoError(t, os.WriteFile(bin, []byte("x"), 0644))
+		legacy := filepath.Join(tmp, "java-project")
+		require.NoError(t, os.MkdirAll(filepath.Join(legacy, "src"), 0755))
+		keep := filepath.Join(tmp, "other-dir")
+		require.NoError(t, os.MkdirAll(keep, 0755))
+
+		cleanLocalJavaBinaryProjectDirs(logger, bin, true)
+
+		_, err := os.Stat(legacy)
+		require.True(t, os.IsNotExist(err))
+		_, err = os.Stat(keep)
+		require.NoError(t, err)
+	})
+
+	t.Run("no-op when not file input", func(t *testing.T) {
+		tmp := t.TempDir()
+		proj := filepath.Join(tmp, "java-project")
+		require.NoError(t, os.MkdirAll(proj, 0755))
+		cleanLocalJavaBinaryProjectDirs(logger, tmp, false)
+		_, err := os.Stat(proj)
+		require.NoError(t, err)
+	})
+
+	t.Run("removes java-project for any file path when isFileInput true", func(t *testing.T) {
+		tmp := t.TempDir()
+		f := filepath.Join(tmp, "readme.txt")
+		require.NoError(t, os.WriteFile(f, []byte("x"), 0644))
+		proj := filepath.Join(tmp, "java-project")
+		require.NoError(t, os.MkdirAll(proj, 0755))
+		cleanLocalJavaBinaryProjectDirs(logger, f, true)
+		_, err := os.Stat(proj)
+		require.True(t, os.IsNotExist(err))
+	})
+}


### PR DESCRIPTION
Fixes #804 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Use separate container images and dedicated provider binaries for Go, Python, and Node.js (instead of a single generic provider).
  * Runtime image now exposes GOROOT for Go tooling.

* **Bug Fixes**
  * Improved cleanup to remove temporary decompiled Java project directories after binary analysis.

* **Tests**
  * Added tests covering Java project directory cleanup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->