### PR TITLE
:bug: Support external-only providers via override settings file

### DIFF
--- a/cmd/analyze/analyze.go
+++ b/cmd/analyze/analyze.go
@@ -54,6 +54,8 @@ type analyzeCommand struct {
 	disableMavenSearch       bool
 	noProgress               bool
 	overrideProviderSettings string
+	parsedOverrideConfigs    []provider.Config // loaded early for mode selection
+	externalOnly             bool              // true when only builtin + external providers needed
 	staticReportPath         string
 	profileDir               string
 	profilePath              string
@@ -154,6 +156,17 @@ func NewAnalyzeCmd(log logr.Logger) *cobra.Command {
 				}
 				return nil
 			}
+			// --- Load override provider settings early ---
+			// This must happen before provider detection so external providers
+			// from the override file can influence mode selection.
+			overrideConfigs, err := analyzeCmd.loadOverrideProviderSettings()
+			if err != nil {
+				return fmt.Errorf("failed to load override provider settings: %w", err)
+			}
+			analyzeCmd.parsedOverrideConfigs = overrideConfigs
+			externalNames := externalProviderNames(overrideConfigs)
+			overrideNames := overrideProviderNameSet(overrideConfigs)
+
 			languages, err := recognizer.Analyze(analyzeCmd.input)
 			if err != nil {
 				log.Error(err, "Failed to determine languages for input")
@@ -182,14 +195,46 @@ func NewAnalyzeCmd(log logr.Logger) *cobra.Command {
 					log.Error(err, "failed to set provider info")
 					return err
 				}
-				err = analyzeCmd.validateProviders(foundProviders)
+				err = analyzeCmd.validateProviders(foundProviders, overrideNames)
 				if err != nil {
 					return err
 				}
 			}
 
+			// When the override file introduces non-standard external providers
+			// (providers kantra doesn't natively manage) and the user did NOT
+			// explicitly select providers via --provider, ignore Alizer-detected
+			// providers. The user's intent is to use only their external provider.
+			providerFlagUsed := len(analyzeCmd.provider) > 0
+			if !providerFlagUsed && hasNonStandardExternalProviders(overrideConfigs) {
+				log.V(1).Info("override introduces non-standard external providers, clearing Alizer-detected providers",
+					"detected", foundProviders, "external", externalNames)
+				foundProviders = []string{}
+			}
+
+			// Determine if only external providers are needed (no kantra-managed ones).
+			// This allows running without Java when the user has their own provider.
+			allExternalOnly := isExternalOnly(foundProviders, externalNames)
+			analyzeCmd.externalOnly = allExternalOnly
+
+			if allExternalOnly {
+				log.V(1).Info("external-only mode: all providers are user-managed", "external", externalNames)
+				// Auto-disable default rulesets unless the user explicitly enabled them
+				if !cmd.Flags().Lookup("enable-default-rulesets").Changed {
+					analyzeCmd.enableDefaultRulesets = false
+					log.V(1).Info("auto-disabled default rulesets for external-only mode")
+				}
+				// Require --rules when using external-only providers without default rulesets.
+				// The PreRunE validation couldn't catch this because enableDefaultRulesets
+				// was still true at that point.
+				if !analyzeCmd.enableDefaultRulesets && len(analyzeCmd.rules) == 0 {
+					return fmt.Errorf("must specify --rules when using external-only providers (no default rulesets available)")
+				}
+			}
+
 			// default to run container mode if no Java provider found
-			if len(foundProviders) > 0 && !slices.Contains(foundProviders, util.JavaProvider) {
+			// but NOT if all providers are external (user-managed)
+			if !allExternalOnly && len(foundProviders) > 0 && !slices.Contains(foundProviders, util.JavaProvider) {
 				log.V(1).Info("detected non-Java providers, switching to hybrid mode", "providers", foundProviders)
 				analyzeCmd.runLocal = false
 			}

--- a/cmd/analyze/provider_config.go
+++ b/cmd/analyze/provider_config.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/konveyor-ecosystem/kantra/pkg/util"
 	outputv1 "github.com/konveyor/analyzer-lsp/output/v1/konveyor"
 	"github.com/konveyor/analyzer-lsp/provider"
 	"github.com/spf13/cobra"
@@ -123,6 +124,74 @@ func mergeProviderSpecificConfig(base, override map[string]interface{}) map[stri
 		result[k] = v
 	}
 	return result
+}
+
+// externalProviderNames returns the names of providers in the override configs
+// that have an Address set, indicating they are externally managed by the user.
+// These providers don't need kantra to start any infrastructure for them.
+func externalProviderNames(overrides []provider.Config) []string {
+	var names []string
+	for _, cfg := range overrides {
+		if cfg.Address != "" {
+			names = append(names, cfg.Name)
+		}
+	}
+	return names
+}
+
+// overrideProviderNameSet returns a set of all provider names in the override configs.
+func overrideProviderNameSet(overrides []provider.Config) map[string]bool {
+	names := make(map[string]bool, len(overrides))
+	for _, cfg := range overrides {
+		names[cfg.Name] = true
+	}
+	return names
+}
+
+// standardProviderNames lists the provider names that kantra manages natively.
+var standardProviderNames = map[string]bool{
+	util.JavaProvider:   true,
+	"builtin":           true,
+	util.GoProvider:     true,
+	util.PythonProvider: true,
+	util.NodeJSProvider: true,
+	util.CsharpProvider: true,
+}
+
+// hasNonStandardExternalProviders returns true if the override configs contain
+// at least one provider with an Address set whose name is NOT a standard
+// kantra-managed provider. This signals that the user is introducing a
+// completely new external provider rather than just tweaking an existing one.
+func hasNonStandardExternalProviders(overrides []provider.Config) bool {
+	for _, cfg := range overrides {
+		if cfg.Address != "" && !standardProviderNames[cfg.Name] {
+			return true
+		}
+	}
+	return false
+}
+
+// isExternalOnly returns true when all detected providers are externally
+// managed (appear in externalNames) or no providers were detected but
+// external overrides exist. This determines whether kantra can skip
+// Java-specific validation and use only builtin + external providers.
+func isExternalOnly(foundProviders []string, externalNames []string) bool {
+	if len(externalNames) == 0 {
+		return false
+	}
+	if len(foundProviders) == 0 {
+		return true
+	}
+	externalSet := make(map[string]bool, len(externalNames))
+	for _, name := range externalNames {
+		externalSet[name] = true
+	}
+	for _, p := range foundProviders {
+		if !externalSet[p] {
+			return false
+		}
+	}
+	return true
 }
 
 // applyAllProviderOverrides merges override configs into the base provider config list.

--- a/cmd/analyze/provider_config_test.go
+++ b/cmd/analyze/provider_config_test.go
@@ -4,14 +4,17 @@ import (
 	"testing"
 
 	"github.com/go-logr/logr/testr"
+	"github.com/konveyor/analyzer-lsp/provider"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func Test_analyzeCommand_validateProviders(t *testing.T) {
 	tests := []struct {
-		name      string
-		providers []string
-		wantErr   bool
+		name          string
+		providers     []string
+		overrideNames map[string]bool
+		wantErr       bool
 	}{
 		{
 			name:      "valid single provider",
@@ -43,6 +46,24 @@ func Test_analyzeCommand_validateProviders(t *testing.T) {
 			providers: []string{"java", "invalid-provider"},
 			wantErr:   true,
 		},
+		{
+			name:          "override provider is accepted",
+			providers:     []string{"my-custom-provider"},
+			overrideNames: map[string]bool{"my-custom-provider": true},
+			wantErr:       false,
+		},
+		{
+			name:          "mix of builtin and override providers",
+			providers:     []string{"java", "my-custom-provider"},
+			overrideNames: map[string]bool{"my-custom-provider": true},
+			wantErr:       false,
+		},
+		{
+			name:          "unknown provider not in overrides still fails",
+			providers:     []string{"unknown"},
+			overrideNames: map[string]bool{"my-custom-provider": true},
+			wantErr:       true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -51,7 +72,11 @@ func Test_analyzeCommand_validateProviders(t *testing.T) {
 				AnalyzeCommandContext: AnalyzeCommandContext{log: testr.NewWithOptions(t, testr.Options{Verbosity: 5})},
 			}
 
-			err := a.validateProviders(tt.providers)
+			overrideNames := tt.overrideNames
+			if overrideNames == nil {
+				overrideNames = map[string]bool{}
+			}
+			err := a.validateProviders(tt.providers, overrideNames)
 			if tt.wantErr {
 				require.Error(t, err)
 			} else {
@@ -59,4 +84,278 @@ func Test_analyzeCommand_validateProviders(t *testing.T) {
 			}
 		})
 	}
+}
+
+func Test_externalProviderNames(t *testing.T) {
+	tests := []struct {
+		name      string
+		overrides []provider.Config
+		want      []string
+	}{
+		{
+			name:      "nil overrides",
+			overrides: nil,
+			want:      nil,
+		},
+		{
+			name:      "empty overrides",
+			overrides: []provider.Config{},
+			want:      nil,
+		},
+		{
+			name: "override with address returns name",
+			overrides: []provider.Config{
+				{Name: "my-provider", Address: "localhost:9999"},
+			},
+			want: []string{"my-provider"},
+		},
+		{
+			name: "override without address excluded",
+			overrides: []provider.Config{
+				{Name: "java"}, // no Address — tweaking existing provider settings
+			},
+			want: nil,
+		},
+		{
+			name: "mix of addressed and non-addressed",
+			overrides: []provider.Config{
+				{Name: "java"},
+				{Name: "my-provider", Address: "localhost:9999"},
+				{Name: "another-provider", Address: "localhost:8888"},
+			},
+			want: []string{"my-provider", "another-provider"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := externalProviderNames(tt.overrides)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func Test_overrideProviderNameSet(t *testing.T) {
+	tests := []struct {
+		name      string
+		overrides []provider.Config
+		want      map[string]bool
+	}{
+		{
+			name:      "empty overrides",
+			overrides: []provider.Config{},
+			want:      map[string]bool{},
+		},
+		{
+			name: "returns all names regardless of address",
+			overrides: []provider.Config{
+				{Name: "java"},
+				{Name: "my-provider", Address: "localhost:9999"},
+			},
+			want: map[string]bool{"java": true, "my-provider": true},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := overrideProviderNameSet(tt.overrides)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func Test_hasNonStandardExternalProviders(t *testing.T) {
+	tests := []struct {
+		name      string
+		overrides []provider.Config
+		want      bool
+	}{
+		{
+			name:      "nil overrides",
+			overrides: nil,
+			want:      false,
+		},
+		{
+			name: "standard provider with address is not non-standard",
+			overrides: []provider.Config{
+				{Name: "java", Address: "localhost:9999"},
+			},
+			want: false,
+		},
+		{
+			name: "standard provider without address is not non-standard",
+			overrides: []provider.Config{
+				{Name: "java"},
+			},
+			want: false,
+		},
+		{
+			name: "non-standard provider with address is detected",
+			overrides: []provider.Config{
+				{Name: "my-custom-provider", Address: "localhost:9999"},
+			},
+			want: true,
+		},
+		{
+			name: "non-standard provider without address is not detected",
+			overrides: []provider.Config{
+				{Name: "my-custom-provider"}, // no address — not externally managed
+			},
+			want: false,
+		},
+		{
+			name: "mix: standard with address + non-standard with address",
+			overrides: []provider.Config{
+				{Name: "java", Address: "localhost:8888"},
+				{Name: "my-custom-provider", Address: "localhost:9999"},
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := hasNonStandardExternalProviders(tt.overrides)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func Test_isExternalOnly(t *testing.T) {
+	tests := []struct {
+		name           string
+		foundProviders []string
+		externalNames  []string
+		want           bool
+	}{
+		{
+			name:           "no providers and no externals",
+			foundProviders: []string{},
+			externalNames:  []string{},
+			want:           false,
+		},
+		{
+			name:           "no detected providers but externals exist",
+			foundProviders: []string{},
+			externalNames:  []string{"my-provider"},
+			want:           true,
+		},
+		{
+			name:           "detected provider matches external",
+			foundProviders: []string{"my-provider"},
+			externalNames:  []string{"my-provider"},
+			want:           true,
+		},
+		{
+			name:           "detected provider is not external",
+			foundProviders: []string{"java"},
+			externalNames:  []string{"my-provider"},
+			want:           false,
+		},
+		{
+			name:           "mix of detected and external — java blocks external-only",
+			foundProviders: []string{"java", "my-provider"},
+			externalNames:  []string{"my-provider"},
+			want:           false,
+		},
+		{
+			name:           "multiple external providers all match",
+			foundProviders: []string{"provider-a", "provider-b"},
+			externalNames:  []string{"provider-a", "provider-b"},
+			want:           true,
+		},
+		{
+			name:           "external names exist but no detected providers",
+			foundProviders: nil,
+			externalNames:  []string{"my-provider"},
+			want:           true,
+		},
+		{
+			name:           "detected providers but no external names",
+			foundProviders: []string{"java"},
+			externalNames:  nil,
+			want:           false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isExternalOnly(tt.foundProviders, tt.externalNames)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func Test_applyAllProviderOverrides_externalProvider(t *testing.T) {
+	t.Run("external provider appended to builtin-only base", func(t *testing.T) {
+		baseConfigs := []provider.Config{
+			{Name: "builtin"},
+		}
+		overrideConfigs := []provider.Config{
+			{
+				Name:    "my-provider",
+				Address: "localhost:9999",
+				InitConfig: []provider.InitConfig{{
+					AnalysisMode:           "source-only",
+					ProviderSpecificConfig: map[string]interface{}{"key": "value"},
+				}},
+			},
+		}
+
+		result := applyAllProviderOverrides(baseConfigs, overrideConfigs)
+		require.Len(t, result, 2)
+		assert.Equal(t, "builtin", result[0].Name)
+		assert.Equal(t, "my-provider", result[1].Name)
+		assert.Equal(t, "localhost:9999", result[1].Address)
+		assert.Equal(t, "value", result[1].InitConfig[0].ProviderSpecificConfig["key"])
+	})
+
+	t.Run("external provider appended alongside java and builtin", func(t *testing.T) {
+		baseConfigs := []provider.Config{
+			{Name: "java"},
+			{Name: "builtin"},
+		}
+		overrideConfigs := []provider.Config{
+			{Name: "my-provider", Address: "localhost:9999"},
+		}
+
+		result := applyAllProviderOverrides(baseConfigs, overrideConfigs)
+		require.Len(t, result, 3)
+		assert.Equal(t, "java", result[0].Name)
+		assert.Equal(t, "builtin", result[1].Name)
+		assert.Equal(t, "my-provider", result[2].Name)
+	})
+
+	t.Run("override for existing provider merges not appends", func(t *testing.T) {
+		baseConfigs := []provider.Config{
+			{
+				Name: "java",
+				InitConfig: []provider.InitConfig{{
+					ProviderSpecificConfig: map[string]interface{}{"bundles": "/default/path"},
+				}},
+			},
+		}
+		overrideConfigs := []provider.Config{
+			{
+				Name: "java",
+				InitConfig: []provider.InitConfig{{
+					ProviderSpecificConfig: map[string]interface{}{"mavenSettingsFile": "/custom/settings.xml"},
+				}},
+			},
+		}
+
+		result := applyAllProviderOverrides(baseConfigs, overrideConfigs)
+		require.Len(t, result, 1, "should merge, not append")
+		assert.Equal(t, "java", result[0].Name)
+		psc := result[0].InitConfig[0].ProviderSpecificConfig
+		assert.Equal(t, "/default/path", psc["bundles"], "base config preserved")
+		assert.Equal(t, "/custom/settings.xml", psc["mavenSettingsFile"], "override applied")
+	})
+
+	t.Run("nil overrides returns base unchanged", func(t *testing.T) {
+		baseConfigs := []provider.Config{{Name: "builtin"}}
+		result := applyAllProviderOverrides(baseConfigs, nil)
+		require.Len(t, result, 1)
+		assert.Equal(t, "builtin", result[0].Name)
+	})
 }

--- a/cmd/analyze/run.go
+++ b/cmd/analyze/run.go
@@ -150,11 +150,12 @@ func (a *analyzeCommand) runAnalysis(ctx context.Context, cmd *cobra.Command, mo
 		Log:                   a.log,
 		KantraDir:             a.kantraDir,
 		DisableMavenSearch:    a.disableMavenSearch,
+		ExternalOnly:          a.externalOnly,
+		EnableDefaultRulesets: a.enableDefaultRulesets,
 		Providers:             buildProviderInfos(foundProviders),
 		ContainerBinary:       settings.Settings.ContainerBinary,
 		RunnerImage:           settings.Settings.RunnerImage,
 		OutputDir:             a.output,
-		EnableDefaultRulesets: a.enableDefaultRulesets,
 		LogLevel:              a.logLevel,
 		Cleanup:               a.cleanup,
 		DepFolders:            a.depFolders,
@@ -182,12 +183,18 @@ func (a *analyzeCommand) runAnalysis(ctx context.Context, cmd *cobra.Command, mo
 		}
 	}
 
-	overrideConfigs, err := a.loadOverrideProviderSettings()
-	if err != nil {
-		return fmt.Errorf("failed to load override provider settings: %w", err)
+	// Reuse override configs loaded early in RunE (for mode selection).
+	// If not loaded yet (e.g., called from a different path), load now.
+	overrideConfigs := a.parsedOverrideConfigs
+	if overrideConfigs == nil && a.overrideProviderSettings != "" {
+		var loadErr error
+		overrideConfigs, loadErr = a.loadOverrideProviderSettings()
+		if loadErr != nil {
+			return fmt.Errorf("failed to load override provider settings: %w", loadErr)
+		}
 	}
 	if overrideConfigs != nil {
-		operationalLog.Info("loaded override provider settings", "file", a.overrideProviderSettings, "providers", len(overrideConfigs))
+		operationalLog.Info("applying override provider settings", "file", a.overrideProviderSettings, "providers", len(overrideConfigs))
 		providerConfigs = applyAllProviderOverrides(providerConfigs, overrideConfigs)
 	}
 

--- a/cmd/analyze/validate.go
+++ b/cmd/analyze/validate.go
@@ -252,7 +252,7 @@ func (a *analyzeCommand) ValidateAndLoadProfile() (*profile.AnalysisProfile, err
 	return foundProfile, nil
 }
 
-func (a *analyzeCommand) validateProviders(providers []string) error {
+func (a *analyzeCommand) validateProviders(providers []string, overrideNames map[string]bool) error {
 	validProvs := []string{
 		util.JavaProvider,
 		util.PythonProvider,
@@ -261,9 +261,13 @@ func (a *analyzeCommand) validateProviders(providers []string) error {
 		util.CsharpProvider,
 	}
 	for _, prov := range providers {
+		// providers defined in the override settings file are always valid
+		if overrideNames[prov] {
+			continue
+		}
 		//validate other providers
 		if !slices.Contains(validProvs, prov) {
-			return fmt.Errorf("provider %v not supported. Use --providerOverride or --provider option", prov)
+			return fmt.Errorf("provider %v not supported. Use --override-provider-settings or --provider option", prov)
 		}
 	}
 	return nil

--- a/pkg/provider/defaults_test.go
+++ b/pkg/provider/defaults_test.go
@@ -237,6 +237,26 @@ func TestDefaultProviderConfig_UnknownProviderSkipped(t *testing.T) {
 	assert.Empty(t, configs)
 }
 
+func TestDefaultProviderConfig_ModeLocal_BuiltinOnly(t *testing.T) {
+	// When Providers is restricted to only "builtin" (as in external-only mode),
+	// no Java provider config should be generated.
+	kantraDir := "/home/user/.kantra"
+	input := "/home/user/project"
+
+	configs := DefaultProviderConfig(ModeLocal, DefaultOptions{
+		Providers: []string{"builtin"},
+		KantraDir: kantraDir,
+		Location:  input,
+	})
+
+	require.Len(t, configs, 1, "should return only builtin provider")
+	assert.Equal(t, "builtin", configs[0].Name)
+	assert.Empty(t, configs[0].BinaryPath, "builtin has no binary")
+	assert.Empty(t, configs[0].Address, "builtin has no address")
+	require.Len(t, configs[0].InitConfig, 1)
+	assert.Equal(t, input, configs[0].InitConfig[0].Location)
+}
+
 // configsByName creates a lookup map from provider configs.
 func configsByName(configs []provider.Config) map[string]provider.Config {
 	m := make(map[string]provider.Config, len(configs))

--- a/pkg/provider/env_local.go
+++ b/pkg/provider/env_local.go
@@ -53,6 +53,10 @@ func newLocalEnvironment(cfg EnvironmentConfig) *localEnvironment {
 
 // Start validates that the host has the required tools and kantra
 // installation for containerless analysis.
+//
+// When ExternalOnly is set, Java-specific validation (mvn, java, JAVA_HOME,
+// and Java bundles) is skipped entirely. Only builtin provider configs are
+// generated; external provider configs are added later via overrides.
 func (e *localEnvironment) Start(ctx context.Context) error {
 	// validate input app is not the current dir
 	// .metadata cannot initialize in the app root
@@ -64,6 +68,42 @@ func (e *localEnvironment) Start(ctx context.Context) error {
 		return fmt.Errorf("input path %s cannot be the current directory", e.cfg.Input)
 	}
 
+	if !e.cfg.ExternalOnly {
+		if err := e.validateJavaPrerequisites(); err != nil {
+			return err
+		}
+	}
+
+	// validate .kantra directory and its contents
+	if err := e.validateKantraDir(); err != nil {
+		return err
+	}
+
+	// generate provider configs now that validation passed
+	providers := AllLocalProviders
+	if e.cfg.ExternalOnly {
+		providers = []string{"builtin"}
+	}
+	e.configs = DefaultProviderConfig(ModeLocal, DefaultOptions{
+		Providers:          providers,
+		KantraDir:          e.cfg.KantraDir,
+		Location:           e.cfg.Input,
+		AnalysisMode:       e.cfg.AnalysisMode,
+		DisableMavenSearch: e.cfg.DisableMavenSearch,
+		MavenSettingsFile:  e.cfg.MavenSettingsFile,
+		JvmMaxMem:          e.cfg.JvmMaxMem,
+		ContextLines:       e.cfg.ContextLines,
+		HTTPProxy:          e.cfg.HTTPProxy,
+		HTTPSProxy:         e.cfg.HTTPSProxy,
+		NoProxy:            e.cfg.NoProxy,
+	})
+
+	return nil
+}
+
+// validateJavaPrerequisites checks that mvn, java 17+, and JAVA_HOME
+// are available on the host. Called only when Java analysis is needed.
+func (e *localEnvironment) validateJavaPrerequisites() error {
 	// validate mvn
 	if _, err := exec.LookPath("mvn"); err != nil {
 		return fmt.Errorf("%w cannot find requirement maven; ensure maven is installed", err)
@@ -93,37 +133,36 @@ func (e *localEnvironment) Start(ctx context.Context) error {
 	if os.Getenv("JAVA_HOME") == "" {
 		return fmt.Errorf("JAVA_HOME is not set; ensure JAVA_HOME is set")
 	}
+	return nil
+}
 
-	// validate .kantra directory and its contents
+// validateKantraDir checks that the kantra installation directory and
+// its required contents exist. When ExternalOnly is set, only the base
+// directory and rulesets (if default rulesets are enabled) are checked.
+func (e *localEnvironment) validateKantraDir() error {
 	kantraDir := e.cfg.KantraDir
-	requiredPaths := []string{
-		kantraDir,
-		filepath.Join(kantraDir, rulesetsSubdir),
-		filepath.Join(kantraDir, javaBundlesSubdir),
-		filepath.Join(kantraDir, jdtlsBinSubdir),
-		filepath.Join(kantraDir, fernflowerJar),
+
+	requiredPaths := []string{kantraDir}
+
+	if e.cfg.EnableDefaultRulesets {
+		requiredPaths = append(requiredPaths, filepath.Join(kantraDir, rulesetsSubdir))
 	}
+
+	if !e.cfg.ExternalOnly {
+		// Java-specific paths only needed when running Java provider
+		requiredPaths = append(requiredPaths,
+			filepath.Join(kantraDir, javaBundlesSubdir),
+			filepath.Join(kantraDir, jdtlsBinSubdir),
+			filepath.Join(kantraDir, fernflowerJar),
+		)
+	}
+
 	for _, p := range requiredPaths {
 		if _, err := os.Stat(p); os.IsNotExist(err) {
 			e.log.Error(err, "cannot open required path, ensure that container-less dependencies are installed")
 			return err
 		}
 	}
-
-	// generate provider configs now that validation passed
-	e.configs = DefaultProviderConfig(ModeLocal, DefaultOptions{
-		KantraDir:          e.cfg.KantraDir,
-		Location:           e.cfg.Input,
-		AnalysisMode:       e.cfg.AnalysisMode,
-		DisableMavenSearch: e.cfg.DisableMavenSearch,
-		MavenSettingsFile:  e.cfg.MavenSettingsFile,
-		JvmMaxMem:          e.cfg.JvmMaxMem,
-		ContextLines:       e.cfg.ContextLines,
-		HTTPProxy:          e.cfg.HTTPProxy,
-		HTTPSProxy:         e.cfg.HTTPSProxy,
-		NoProxy:            e.cfg.NoProxy,
-	})
-
 	return nil
 }
 

--- a/pkg/provider/env_local_test.go
+++ b/pkg/provider/env_local_test.go
@@ -1,0 +1,179 @@
+package provider
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mkMinimalKantraDir creates a kantra directory with only the base dir.
+// No rulesets, no Java bundles — suitable for ExternalOnly mode.
+func mkMinimalKantraDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	return dir
+}
+
+// mkKantraDirWithRulesets creates a kantra directory with a rulesets subdirectory.
+func mkKantraDirWithRulesets(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	err := os.MkdirAll(filepath.Join(dir, rulesetsSubdir), 0755)
+	require.NoError(t, err)
+	return dir
+}
+
+func TestLocalEnvironment_Start_ExternalOnly_NoJavaRequired(t *testing.T) {
+	// Create a minimal kantra dir with no Java artifacts.
+	// ExternalOnly + EnableDefaultRulesets=false should succeed
+	// without mvn, java, JAVA_HOME, or Java bundles.
+	kantraDir := mkMinimalKantraDir(t)
+	inputDir := t.TempDir()
+
+	env := newLocalEnvironment(EnvironmentConfig{
+		Mode:                 ModeLocal,
+		Input:                inputDir,
+		KantraDir:            kantraDir,
+		ExternalOnly:         true,
+		EnableDefaultRulesets: false,
+		Log:                  logr.Discard(),
+	})
+
+	err := env.Start(context.Background())
+	require.NoError(t, err, "Start() should succeed in external-only mode without Java")
+}
+
+func TestLocalEnvironment_Start_ExternalOnly_ProviderConfigsBuiltinOnly(t *testing.T) {
+	// When ExternalOnly=true, ProviderConfigs() should return
+	// only the builtin provider — no Java provider.
+	kantraDir := mkMinimalKantraDir(t)
+	inputDir := t.TempDir()
+
+	env := newLocalEnvironment(EnvironmentConfig{
+		Mode:                 ModeLocal,
+		Input:                inputDir,
+		KantraDir:            kantraDir,
+		ExternalOnly:         true,
+		EnableDefaultRulesets: false,
+		Log:                  logr.Discard(),
+	})
+
+	err := env.Start(context.Background())
+	require.NoError(t, err)
+
+	configs := env.ProviderConfigs()
+	require.Len(t, configs, 1, "should return only builtin provider")
+	assert.Equal(t, "builtin", configs[0].Name)
+}
+
+func TestLocalEnvironment_Start_ExternalOnly_WithDefaultRulesets(t *testing.T) {
+	// ExternalOnly with EnableDefaultRulesets=true requires rulesets dir to exist.
+	kantraDir := mkKantraDirWithRulesets(t)
+	inputDir := t.TempDir()
+
+	env := newLocalEnvironment(EnvironmentConfig{
+		Mode:                 ModeLocal,
+		Input:                inputDir,
+		KantraDir:            kantraDir,
+		ExternalOnly:         true,
+		EnableDefaultRulesets: true,
+		Log:                  logr.Discard(),
+	})
+
+	err := env.Start(context.Background())
+	require.NoError(t, err, "Start() should succeed when rulesets dir exists")
+
+	// Rules should include the default rulesets path
+	rules, err := env.Rules(nil, true)
+	require.NoError(t, err)
+	require.Len(t, rules, 1)
+	assert.Equal(t, filepath.Join(kantraDir, rulesetsSubdir), rules[0])
+}
+
+func TestLocalEnvironment_Start_ExternalOnly_MissingRulesetsDir(t *testing.T) {
+	// ExternalOnly with EnableDefaultRulesets=true should fail when
+	// the rulesets directory does not exist.
+	kantraDir := mkMinimalKantraDir(t) // no rulesets subdir
+	inputDir := t.TempDir()
+
+	env := newLocalEnvironment(EnvironmentConfig{
+		Mode:                 ModeLocal,
+		Input:                inputDir,
+		KantraDir:            kantraDir,
+		ExternalOnly:         true,
+		EnableDefaultRulesets: true,
+		Log:                  logr.Discard(),
+	})
+
+	err := env.Start(context.Background())
+	require.Error(t, err, "Start() should fail when rulesets dir is missing and default rulesets enabled")
+}
+
+func TestLocalEnvironment_Start_ExternalOnly_RulesWithoutDefaults(t *testing.T) {
+	// When EnableDefaultRulesets=false, Rules() should not include
+	// default rulesets path even if the dir exists.
+	kantraDir := mkKantraDirWithRulesets(t)
+	inputDir := t.TempDir()
+
+	env := newLocalEnvironment(EnvironmentConfig{
+		Mode:                 ModeLocal,
+		Input:                inputDir,
+		KantraDir:            kantraDir,
+		ExternalOnly:         true,
+		EnableDefaultRulesets: false,
+		Log:                  logr.Discard(),
+	})
+
+	err := env.Start(context.Background())
+	require.NoError(t, err)
+
+	userRules := []string{"/path/to/my/rules"}
+	rules, err := env.Rules(userRules, false)
+	require.NoError(t, err)
+	require.Len(t, rules, 1, "should contain only user rules")
+	assert.Equal(t, "/path/to/my/rules", rules[0])
+}
+
+func TestLocalEnvironment_Start_InputIsCwd(t *testing.T) {
+	// Setting input to the current directory should fail regardless
+	// of ExternalOnly setting.
+	kantraDir := mkMinimalKantraDir(t)
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+
+	env := newLocalEnvironment(EnvironmentConfig{
+		Mode:                 ModeLocal,
+		Input:                cwd,
+		KantraDir:            kantraDir,
+		ExternalOnly:         true,
+		EnableDefaultRulesets: false,
+		Log:                  logr.Discard(),
+	})
+
+	err = env.Start(context.Background())
+	require.Error(t, err, "Start() should fail when input is the current directory")
+	assert.Contains(t, err.Error(), "cannot be the current directory")
+}
+
+func TestLocalEnvironment_Stop_CleansUpEclipseDirs(t *testing.T) {
+	kantraDir := mkMinimalKantraDir(t)
+	inputDir := t.TempDir()
+
+	env := newLocalEnvironment(EnvironmentConfig{
+		Mode:                 ModeLocal,
+		Input:                inputDir,
+		KantraDir:            kantraDir,
+		ExternalOnly:         true,
+		EnableDefaultRulesets: false,
+		Log:                  logr.Discard(),
+	})
+
+	// Stop should not error even if no eclipse dirs exist
+	err := env.Stop(context.Background())
+	require.NoError(t, err)
+}

--- a/pkg/provider/environment.go
+++ b/pkg/provider/environment.go
@@ -104,6 +104,18 @@ type EnvironmentConfig struct {
 	// DisableMavenSearch disables Maven central search for the Java provider.
 	DisableMavenSearch bool
 
+	// ExternalOnly indicates that only builtin + user-managed external
+	// providers are needed. When true, the local environment skips
+	// Java-specific validation (mvn, java, JAVA_HOME, Java bundles)
+	// and generates only builtin provider configs. External provider
+	// configs are added later via --override-provider-settings.
+	ExternalOnly bool
+
+	// EnableDefaultRulesets controls whether default rulesets are used.
+	// In local mode, controls kantraDir/rulesets validation.
+	// In container mode, controls whether rulesets are extracted.
+	EnableDefaultRulesets bool
+
 	// -- Container mode fields (ignored in local mode) --
 
 	// Providers lists the providers to start in containers.
@@ -117,9 +129,6 @@ type EnvironmentConfig struct {
 
 	// OutputDir is the analysis output directory (used for ruleset cache).
 	OutputDir string
-
-	// EnableDefaultRulesets controls whether default rulesets are extracted.
-	EnableDefaultRulesets bool
 
 	// LogLevel for provider containers.
 	LogLevel *uint32


### PR DESCRIPTION
Enable running kantra with user-managed external providers without requiring Java, Maven, or container infrastructure. When the override settings file introduces non-standard providers with an Address, kantra now skips Alizer-detected provider setup, Java validation, and auto-disables default rulesets.

Key changes:
- Load override settings early in RunE to influence mode selection
- Skip Java prerequisites when only builtin + external providers needed
- Clear Alizer-detected providers when non-standard externals present
- Accept override provider names in validateProviders
- Require --rules in external-only mode (no default rulesets available)
- Refactor env_local.go Start() into testable validation methods
- Add comprehensive tests (27 new test cases across 3 files)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for external provider configuration and overrides.
  * Introduced external-only mode that eliminates Java prerequisites when using only external providers.

* **Improvements**
  * Enhanced provider validation to recognize custom provider overrides.
  * Default rulesets now auto-disable in external-only mode unless explicitly enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->