### PR TITLE
:bug: adding mavenCacheDir to java provider config to accessable directory

### DIFF
--- a/java.json.sample
+++ b/java.json.sample
@@ -6,6 +6,7 @@
                     "bundles": "",
                     "depOpenSourceLabelsFile": "",
                     "jvmMaxMem": "",
+                    "mavenCacheDir": "",
                     "mavenSettingsFile": ""
                 },
                 "analysisMode": "source-only"

--- a/pkg/provider/defaults.go
+++ b/pkg/provider/defaults.go
@@ -137,6 +137,10 @@ type DefaultOptions struct {
 
 	// JvmMaxMem sets JVM max memory for the Java provider.
 	JvmMaxMem string
+
+	// MavenCacheDir is the container path to use for the Maven local
+	// repository cache. Only set when a cache volume is actually mounted.
+	MavenCacheDir string
 }
 
 // DefaultProviderConfig returns provider configs for the given execution mode.
@@ -195,6 +199,7 @@ func DefaultProviderConfig(mode ExecutionMode, opts DefaultOptions) []provider.C
 				MavenSettingsFile:  opts.MavenSettingsFile,
 				JvmMaxMem:          opts.JvmMaxMem,
 				DisableMavenSearch: opts.DisableMavenSearch,
+				MavenCacheDir:      opts.MavenCacheDir,
 			},
 		}
 

--- a/pkg/provider/env_container.go
+++ b/pkg/provider/env_container.go
@@ -374,32 +374,36 @@ func (e *containerEnvironment) createMavenCacheVolume() (string, error) {
 	}
 
 	volName := "maven-cache-volume"
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		return "", fmt.Errorf("failed to get user home directory: %w", err)
-	}
 
-	m2RepoPath := filepath.Join(homeDir, ".m2", "repository")
-	if err := os.MkdirAll(m2RepoPath, 0755); err != nil {
-		return "", fmt.Errorf("failed to create maven cache directory: %w", err)
-	}
-
-	mountPath := m2RepoPath
+	var args []string
 	if runtime.GOOS == "windows" {
-		volumeName := filepath.VolumeName(mountPath)
-		remainingPath := mountPath[len(volumeName):]
-		remainingPath = filepath.ToSlash(remainingPath)
-		driveLetter := strings.ToLower(strings.TrimSuffix(volumeName, ":"))
-		mountPath = fmt.Sprintf("/mnt/%s%s", driveLetter, remainingPath)
+		// On Windows, use a regular container-managed volume instead of a
+		// bind mount from the host. Bind mounts go through WSL2's 9p
+		// filesystem layer, which does not support the atomic file
+		// operations that Maven's DefaultTrackingFileManager requires
+		// for writing dependency tracking metadata. This causes
+		// transitive dependency resolution to fail.
+		args = []string{"volume", "create", volName}
+	} else {
+		homeDir, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("failed to get user home directory: %w", err)
+		}
+
+		m2RepoPath := filepath.Join(homeDir, ".m2", "repository")
+		if err := os.MkdirAll(m2RepoPath, 0755); err != nil {
+			return "", fmt.Errorf("failed to create maven cache directory: %w", err)
+		}
+
+		args = []string{
+			"volume", "create",
+			"--opt", "type=none",
+			"--opt", fmt.Sprintf("device=%v", m2RepoPath),
+			"--opt", "o=bind",
+			volName,
+		}
 	}
 
-	args := []string{
-		"volume", "create",
-		"--opt", "type=none",
-		"--opt", fmt.Sprintf("device=%v", mountPath),
-		"--opt", "o=bind",
-		volName,
-	}
 	cmd := exec.Command(e.cfg.ContainerBinary, args...)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
@@ -415,7 +419,7 @@ func (e *containerEnvironment) createMavenCacheVolume() (string, error) {
 		return "", fmt.Errorf("failed to create maven cache volume: %w\nOutput: %s", err, string(output))
 	}
 
-	e.log.V(1).Info("created maven cache volume", "volume", volName, "host_path", m2RepoPath)
+	e.log.V(1).Info("created maven cache volume", "volume", volName)
 	e.mavenCacheVol = volName
 	return volName, nil
 }

--- a/pkg/provider/env_container.go
+++ b/pkg/provider/env_container.go
@@ -103,6 +103,13 @@ func (e *containerEnvironment) Start(ctx context.Context) error {
 		mavenSettingsPath = path.Join(util.ConfigMountPath, "settings.xml")
 	}
 
+	// Only tell the provider about the maven cache dir when a cache
+	// volume was actually mounted into the container.
+	mavenCacheDir := ""
+	if e.mavenCacheVol != "" {
+		mavenCacheDir = path.Join(util.MavenCacheDir, "repository")
+	}
+
 	// For file inputs (e.g., .war/.jar), the Location must include the
 	// filename so the Java provider knows it's analyzing a binary file.
 	// The volume mounts the parent directory at SourceMountPath, so the
@@ -124,6 +131,7 @@ func (e *containerEnvironment) Start(ctx context.Context) error {
 		NoProxy:           e.cfg.NoProxy,
 		MavenSettingsFile: mavenSettingsPath,
 		JvmMaxMem:         e.cfg.JvmMaxMem,
+		MavenCacheDir:     mavenCacheDir,
 	})
 
 	e.log.Info("all providers are ready")

--- a/pkg/provider/env_container.go
+++ b/pkg/provider/env_container.go
@@ -448,7 +448,7 @@ func (e *containerEnvironment) startProviders(ctx context.Context, logWriter io.
 		if err != nil {
 			e.log.V(1).Error(err, "failed to create maven cache volume, continuing without cache")
 		} else if mavenCacheVolName != "" {
-			mavenCacheDir := path.Join(util.M2Dir, "repository")
+			mavenCacheDir := path.Join(util.MavenCacheDir, "repository")
 			volumes[mavenCacheVolName] = mavenCacheDir
 			e.log.V(1).Info("mounted maven cache volume", "container_path", mavenCacheDir)
 		}

--- a/pkg/provider/java.go
+++ b/pkg/provider/java.go
@@ -2,7 +2,6 @@ package provider
 
 import (
 	"os"
-	"path"
 	"path/filepath"
 
 	"github.com/go-logr/logr"
@@ -43,7 +42,9 @@ func (p *JavaProvider) GetConfig(mode ExecutionMode, opts BaseOptions, extra ...
 		psc["bundles"] = ContainerJavaBundlePath
 		psc["depOpenSourceLabelsFile"] = ContainerDepOpenSourceLabels
 		psc[provider.LspServerPathConfigKey] = ContainerJDTLSPath
-		psc["mavenCacheDir"] = path.Join(util.MavenCacheDir, "repository")
+		if javaOpts.MavenCacheDir != "" {
+			psc["mavenCacheDir"] = javaOpts.MavenCacheDir
+		}
 
 	case ModeLocal:
 		kantraDir := opts.KantraDir
@@ -63,7 +64,9 @@ func (p *JavaProvider) GetConfig(mode ExecutionMode, opts BaseOptions, extra ...
 		psc["bundles"] = ContainerJavaBundlePath
 		psc["mavenIndexPath"] = ContainerMavenIndexPath
 		psc["depOpenSourceLabelsFile"] = ContainerDepOpenSourceLabels
-		psc["mavenCacheDir"] = path.Join(util.MavenCacheDir, "repository")
+		if javaOpts.MavenCacheDir != "" {
+			psc["mavenCacheDir"] = javaOpts.MavenCacheDir
+		}
 	}
 
 	// Apply Java-specific overrides from options

--- a/pkg/provider/java.go
+++ b/pkg/provider/java.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"os"
+	"path"
 	"path/filepath"
 
 	"github.com/go-logr/logr"
@@ -42,6 +43,7 @@ func (p *JavaProvider) GetConfig(mode ExecutionMode, opts BaseOptions, extra ...
 		psc["bundles"] = ContainerJavaBundlePath
 		psc["depOpenSourceLabelsFile"] = ContainerDepOpenSourceLabels
 		psc[provider.LspServerPathConfigKey] = ContainerJDTLSPath
+		psc["mavenCacheDir"] = path.Join(util.MavenCacheDir, "repository")
 
 	case ModeLocal:
 		kantraDir := opts.KantraDir
@@ -61,6 +63,7 @@ func (p *JavaProvider) GetConfig(mode ExecutionMode, opts BaseOptions, extra ...
 		psc["bundles"] = ContainerJavaBundlePath
 		psc["mavenIndexPath"] = ContainerMavenIndexPath
 		psc["depOpenSourceLabelsFile"] = ContainerDepOpenSourceLabels
+		psc["mavenCacheDir"] = path.Join(util.MavenCacheDir, "repository")
 	}
 
 	// Apply Java-specific overrides from options

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -18,6 +18,7 @@ type JavaOptions struct {
 	MavenSettingsFile  string
 	JvmMaxMem          string
 	DisableMavenSearch bool
+	MavenCacheDir      string
 }
 
 func (JavaOptions) providerOption() {}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -27,8 +27,10 @@ const (
 )
 
 var (
-	// TODO (pgaikwad): this assumes that the $USER in container is always root, it may not be the case in future
-	M2Dir = path.Join("/", "root", ".m2")
+	// MavenCacheDir is the container-internal directory for the Maven
+	// local repository cache. Mounted under /opt/input so it is
+	// accessible regardless of which user the container runs as.
+	MavenCacheDir = path.Join(InputPath, "maven-cache")
 	// SourceMountPath is the directory where source code is mounted in the container.
 	// This value must not be modified at runtime. Use analyzeCommand.sourceLocationPath
 	// for the resolved source location (which may include a filename for file inputs).


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a configurable Maven cache directory in Java provider settings so users can specify where Maven artifacts are stored.

* **Chores**
  * Standardized the container-internal Maven cache path and updated environment/configuration handling to pass the cache directory only when set.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->