### PR TITLE
:bug: Do not disable dependency rules in tests

### DIFF
--- a/pkg/testing/runner.go
+++ b/pkg/testing/runner.go
@@ -273,7 +273,6 @@ func runWithEnvironment(logger logr.Logger, opts TestOptions, testsFile TestsFil
 		konveyorAnalyzer.WithRuleFilepaths([]string{rulesPath}),
 		konveyorAnalyzer.WithLogger(logger),
 		konveyorAnalyzer.WithContext(ctx),
-		konveyorAnalyzer.WithDependencyRulesDisabled(),
 	}
 	if analysisParams.DepLabelSelector != "" {
 		analyzerOpts = append(analyzerOpts,


### PR DESCRIPTION
For some reason we disabled at some point the dependency rules when running tests. Dependency rules should also be evaluated for rule tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Dependency rules are now processed during in-process analyzer execution instead of being explicitly disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->