### PR TITLE
Fix for bug https://github.com/konveyor/kantra/issues/788

### DIFF
--- a/cmd/analyze/run.go
+++ b/cmd/analyze/run.go
@@ -43,6 +43,7 @@ import (
 //  13. Post-analysis (e.g., provider log collection)
 //  14. Output writing (YAML, JSON, static report)
 //  15. Results summary
+//
 // setProxyEnvironment sets proxy environment variables in the current process
 // from the CLI flags. This ensures all child processes (providers, language servers,
 // etc.) inherit the proxy settings. Sets both lower and upper case variants for
@@ -364,7 +365,9 @@ func (a *analyzeCommand) runAnalysis(ctx context.Context, cmd *cobra.Command, mo
 	// Print results summary
 	progressMode.Println("\nResults:")
 	reportPath := filepath.Join(a.output, "static-report", "index.html")
-	progressMode.Printf("  Report: file://%s\n", reportPath)
+	if !a.skipStaticReport {
+		progressMode.Printf("  Report: file://%s\n", reportPath)
+	}
 	analysisLogPath := filepath.Join(a.output, "analysis.log")
 	progressMode.Printf("  Analysis logs: %s\n", analysisLogPath)
 


### PR DESCRIPTION
Fix for the bug Output contains path to a HTML report file even when --skip-static-report is used https://github.com/konveyor/kantra/issues/788

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Static report URL output now correctly respects the skip-static-report configuration flag.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->