### PR TITLE
Added overriding of podman arguments from kantra CLI

### DIFF
--- a/cmd/analyze/analyze.go
+++ b/cmd/analyze/analyze.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"strings"
 
 	kantraProvider "github.com/konveyor-ecosystem/kantra/pkg/provider"
 
@@ -53,6 +54,7 @@ type analyzeCommand struct {
 	runLocal                 bool
 	disableMavenSearch       bool
 	noProgress               bool
+	containerRuntimeFlags    string
 	overrideProviderSettings string
 	parsedOverrideConfigs    []provider.Config // loaded early for mode selection
 	externalOnly             bool              // true when only builtin + external providers needed
@@ -316,8 +318,22 @@ func NewAnalyzeCmd(log logr.Logger) *cobra.Command {
 	analyzeCommand.Flags().BoolVar(&analyzeCmd.runLocal, "run-local", true, "run Java analysis in containerless mode")
 	analyzeCommand.Flags().BoolVar(&analyzeCmd.disableMavenSearch, "disable-maven-search", false, "disable maven search for dependencies")
 	analyzeCommand.Flags().BoolVar(&analyzeCmd.noProgress, "no-progress", false, "disable progress reporting (useful for scripting)")
+	analyzeCommand.Flags().StringVar(&analyzeCmd.containerRuntimeFlags, "container-runtime-flags", "", "additional flags passed to the container runtime for run commands, for example: \"--memory 4G --cpus 4\"")
 	analyzeCommand.Flags().StringVar(&analyzeCmd.overrideProviderSettings, "override-provider-settings", "", "override provider settings with custom provider config file")
 	analyzeCommand.Flags().StringVar(&analyzeCmd.staticReportPath, "static-report-path", "", "override the default static report template location")
 	analyzeCommand.Flags().StringVar(&analyzeCmd.profileDir, "profile-dir", "", "path to a directory containing analysis profiles")
 	return analyzeCommand
+}
+
+func (a *analyzeCommand) containerRuntimeArgs() []string {
+	if a.parsedContainerRuntime != nil {
+		return a.parsedContainerRuntime
+	}
+	args, err := parseContainerRuntimeFlags(a.containerRuntimeFlags)
+	if err != nil {
+		// Validation should catch malformed flags first, but keep a best-effort
+		// fallback for direct unit usage paths.
+		return strings.Fields(a.containerRuntimeFlags)
+	}
+	return args
 }

--- a/cmd/analyze/analyze_test.go
+++ b/cmd/analyze/analyze_test.go
@@ -1345,6 +1345,70 @@ func Test_analyzeCommand_disableMavenSearch_flagParsing(t *testing.T) {
 		})
 	}
 }
+
+func Test_analyzeCommand_containerRuntimeFlagsParsing(t *testing.T) {
+	a := &analyzeCommand{
+		containerRuntimeFlags: "--memory 4G --cpus 4",
+	}
+	want := []string{"--memory", "4G", "--cpus", "4"}
+	if got := a.containerRuntimeArgs(); !reflect.DeepEqual(got, want) {
+		t.Fatalf("containerRuntimeArgs() = %v, want %v", got, want)
+	}
+}
+
+func Test_parseContainerRuntimeFlags(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    []string
+		wantErr bool
+	}{
+		{
+			name:  "basic args",
+			input: "--memory 4G --cpus 4",
+			want:  []string{"--memory", "4G", "--cpus", "4"},
+		},
+		{
+			name:  "quoted value with spaces",
+			input: "--annotation \"io.konveyor.note=hello world\"",
+			want:  []string{"--annotation", "io.konveyor.note=hello world"},
+		},
+		{
+			name:  "single quotes",
+			input: "--label 'com.example/name=my app'",
+			want:  []string{"--label", "com.example/name=my app"},
+		},
+		{
+			name:  "escaped spaces",
+			input: "--label com.example/name=my\\ app",
+			want:  []string{"--label", "com.example/name=my app"},
+		},
+		{
+			name:    "unterminated quote",
+			input:   "--label \"broken",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseContainerRuntimeFlags(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for input %q", tt.input)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseContainerRuntimeFlags() unexpected error: %v", err)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("parseContainerRuntimeFlags() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func Test_JavaProvider_GetConfig_disableMavenSearch(t *testing.T) {
 	tests := []struct {
 		name                       string
@@ -1477,10 +1541,10 @@ func Test_analyzeCommand_Validate_staticReportPath(t *testing.T) {
 			os.WriteFile(filepath.Join(tmpKantraDir, "fernflower.jar"), []byte(""), 0644)
 
 			a := &analyzeCommand{
-				staticReportPath:     reportPath,
-				input:                tmpInput,
-				output:               tmpOutput,
-				mode:                 "full",
+				staticReportPath:      reportPath,
+				input:                 tmpInput,
+				output:                tmpOutput,
+				mode:                  "full",
 				enableDefaultRulesets: true,
 				AnalyzeCommandContext: AnalyzeCommandContext{
 					log:       logr.Discard(),

--- a/cmd/analyze/context.go
+++ b/cmd/analyze/context.go
@@ -1,6 +1,10 @@
 package analyze
 
 import (
+	"fmt"
+	"strings"
+	"unicode"
+
 	"github.com/go-logr/logr"
 )
 
@@ -13,4 +17,56 @@ type AnalyzeCommandContext struct {
 
 	// for containerless cmd
 	kantraDir string
+
+	// parsedContainerRuntime is set during Validate from containerRuntimeFlags on analyzeCommand.
+	parsedContainerRuntime []string
+}
+
+func parseContainerRuntimeFlags(input string) ([]string, error) {
+	var args []string
+	var current strings.Builder
+	inSingle := false
+	inDouble := false
+	escaped := false
+	tokenStarted := false
+
+	flush := func() {
+		if tokenStarted {
+			args = append(args, current.String())
+			current.Reset()
+			tokenStarted = false
+		}
+	}
+
+	for _, r := range input {
+		switch {
+		case escaped:
+			current.WriteRune(r)
+			escaped = false
+			tokenStarted = true
+		case r == '\\' && !inSingle:
+			escaped = true
+			tokenStarted = true
+		case r == '\'' && !inDouble:
+			inSingle = !inSingle
+			tokenStarted = true
+		case r == '"' && !inSingle:
+			inDouble = !inDouble
+			tokenStarted = true
+		case unicode.IsSpace(r) && !inSingle && !inDouble:
+			flush()
+		default:
+			current.WriteRune(r)
+			tokenStarted = true
+		}
+	}
+
+	if escaped {
+		return nil, fmt.Errorf("trailing escape in container runtime flags")
+	}
+	if inSingle || inDouble {
+		return nil, fmt.Errorf("unterminated quote in container runtime flags")
+	}
+	flush()
+	return args, nil
 }

--- a/cmd/analyze/labels.go
+++ b/cmd/analyze/labels.go
@@ -103,6 +103,7 @@ func (a *analyzeCommand) fetchLabels(ctx context.Context, listSources, listTarge
 			ctx,
 			container.WithImage(settings.Settings.RunnerImage),
 			container.WithLog(a.log.V(1)),
+			container.WithRuntimeArgs(a.containerRuntimeArgs()...),
 			container.WithEnv(runMode, runModeContainer),
 			container.WithEnv(rulePath, customRulePath),
 			container.WithVolumes(volumes),

--- a/cmd/analyze/run.go
+++ b/cmd/analyze/run.go
@@ -155,6 +155,7 @@ func (a *analyzeCommand) runAnalysis(ctx context.Context, cmd *cobra.Command, mo
 		EnableDefaultRulesets: a.enableDefaultRulesets,
 		Providers:             buildProviderInfos(foundProviders),
 		ContainerBinary:       settings.Settings.ContainerBinary,
+		ContainerRuntimeArgs:  a.containerRuntimeArgs(),
 		RunnerImage:           settings.Settings.RunnerImage,
 		OutputDir:             a.output,
 		LogLevel:              a.logLevel,

--- a/cmd/analyze/validate.go
+++ b/cmd/analyze/validate.go
@@ -18,6 +18,12 @@ import (
 )
 
 func (a *analyzeCommand) Validate(ctx context.Context, cmd *cobra.Command, foundProfile *profile.AnalysisProfile) error {
+	parsedContainerRuntime, err := parseContainerRuntimeFlags(a.containerRuntimeFlags)
+	if err != nil {
+		return fmt.Errorf("invalid --container-runtime-flags: %w", err)
+	}
+	a.parsedContainerRuntime = parsedContainerRuntime
+
 	if a.listSources || a.listTargets || a.listProviders {
 		return nil
 	}
@@ -122,7 +128,7 @@ func (a *analyzeCommand) Validate(ctx context.Context, cmd *cobra.Command, found
 			a.isFileInput = true
 		}
 	}
-	err := a.CheckOverwriteOutput()
+	err = a.CheckOverwriteOutput()
 	if err != nil {
 		return err
 	}

--- a/pkg/container/container.go
+++ b/pkg/container/container.go
@@ -38,6 +38,7 @@ type container struct {
 	detached         bool
 	log              logr.Logger
 	containerToolBin string
+	runtimeArgs      []string
 	reproducerCmd    *string
 }
 
@@ -76,6 +77,12 @@ func WithEntrypointBin(b string) Option {
 func WithContainerToolBin(r string) Option {
 	return func(c *container) {
 		c.containerToolBin = r
+	}
+}
+
+func WithRuntimeArgs(args ...string) Option {
+	return func(c *container) {
+		c.runtimeArgs = args
 	}
 }
 
@@ -235,6 +242,9 @@ func (c *container) Run(ctx context.Context, opts ...Option) error {
 	}
 	if c.cleanup {
 		args = append(args, "--rm")
+	}
+	if len(c.runtimeArgs) > 0 {
+		args = append(args, c.runtimeArgs...)
 	}
 	if c.Name != "" {
 		args = append(args, "--name")

--- a/pkg/container/container_test.go
+++ b/pkg/container/container_test.go
@@ -111,6 +111,22 @@ func TestRun_WithVolumesAndEnvInReproducer(t *testing.T) {
 	}
 }
 
+func TestRun_WithRuntimeArgsInReproducer(t *testing.T) {
+	reproducer, err := runWithNonexistentTool(
+		t,
+		"/nonexistent/podman",
+		WithRuntimeArgs("--memory", "4G", "--cpus", "4"),
+	)
+	if err == nil {
+		t.Fatal("expected Run to fail when container tool does not exist")
+	}
+	for _, token := range []string{"--memory", "4G", "--cpus", "4"} {
+		if !strings.Contains(reproducer, token) {
+			t.Fatalf("expected reproducer to contain %q, got: %s", token, reproducer)
+		}
+	}
+}
+
 func TestRun_ValidatesRequiredFields(t *testing.T) {
 	ctx := context.Background()
 	t.Run("missing image", func(t *testing.T) {

--- a/pkg/provider/env_container.go
+++ b/pkg/provider/env_container.go
@@ -481,6 +481,7 @@ func (e *containerEnvironment) startProviders(ctx context.Context, logWriter io.
 			ctx,
 			container.WithImage(p.image),
 			container.WithLog(e.log.V(1)),
+			container.WithRuntimeArgs(e.cfg.ContainerRuntimeArgs...),
 			container.WithVolumes(volumes),
 			container.WithContainerToolBin(e.cfg.ContainerBinary),
 			container.WithEntrypointArgs(args...),

--- a/pkg/provider/environment.go
+++ b/pkg/provider/environment.go
@@ -124,6 +124,10 @@ type EnvironmentConfig struct {
 	// ContainerBinary is the path to the container runtime (podman/docker).
 	ContainerBinary string
 
+	// ContainerRuntimeArgs are additional arguments passed to the container
+	// runtime for every "run" invocation (for example --memory and --cpus).
+	ContainerRuntimeArgs []string
+
 	// RunnerImage is the kantra runner container image (for ruleset extraction).
 	RunnerImage string
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a command-line option to supply container runtime flags; provided runtime arguments are forwarded to the analysis container environment.

* **Tests**
  * Added tests for runtime-flag parsing (including quoting/escaping) and for container execution when runtime arguments are supplied.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->