### PR TITLE
[RFR] Assets folder depends on CMD_NAME

### DIFF
--- a/.claude/testing.md
+++ b/.claude/testing.md
@@ -31,6 +31,8 @@ Kantra behavior can be customized via environment variables (see `cmd/settings.g
 - `JVM_MAX_MEM` — JVM maximum memory for Java analysis (e.g., `4g`, `8g`)
 - `CMD_NAME` — Override root command name (default: `kantra`)
 
+Config directory basename (`~/.kantra` by default) is set at **build time** via ldflags (`settings.ConfigDirName`), not at runtime.
+
 ## Analysis Commands
 
 ### Containerless Mode (Default)

--- a/cmd/config/config_test.go
+++ b/cmd/config/config_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/konveyor-ecosystem/kantra/pkg/profile"
+	"github.com/konveyor-ecosystem/kantra/pkg/util"
 	hubapi "github.com/konveyor/tackle2-hub/shared/api"
 	"gopkg.in/yaml.v2"
 )
@@ -47,18 +48,19 @@ func generateMockJWT(expirationTime time.Time) string {
 	return headerB64 + "." + payloadB64 + "." + signatureB64
 }
 
-// setupTempAuth creates a temporary HOME directory and writes auth data to ~/.kantra/auth.json
-// Returns the temp home directory path for cleanup
+// setupTempAuth creates a temporary config directory and writes auth data to auth.json.
+// Returns the temp home directory path for cleanup.
 func setupTempAuth(t *testing.T, auth *LoginResponse) string {
-	// Create temporary home directory
 	tempHome := t.TempDir()
-
-	// Set HOME environment variable to point to temp directory
 	t.Setenv("HOME", tempHome)
+	// GetKantraDir prefers XDG_CONFIG_HOME on Linux; pin the config dir for tests.
+	t.Setenv("XDG_CONFIG_HOME", "")
 
-	// Create .kantra directory in temp home
-	kantreDir := filepath.Join(tempHome, ".kantra")
-	os.MkdirAll(kantreDir, 0755)
+	kantreDir := filepath.Join(tempHome, util.ConfigDirBasename())
+	t.Setenv(util.KantraDirEnv, kantreDir)
+	if err := os.MkdirAll(kantreDir, 0755); err != nil {
+		t.Fatalf("Failed to create config dir: %v", err)
+	}
 
 	// Write auth data if provided
 	if auth != nil {

--- a/cmd/config/login.go
+++ b/cmd/config/login.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/golang-jwt/jwt/v5"
+	"github.com/konveyor-ecosystem/kantra/pkg/util"
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
 )
@@ -244,11 +245,10 @@ func (l *loginCommand) RefreshToken(hubURL string, loginResp *LoginResponse) (*L
 }
 
 func (l *loginCommand) storeTokens(loginResp *LoginResponse) error {
-	homeDir, err := os.UserHomeDir()
+	kantraDir, err := util.GetKantraDir()
 	if err != nil {
 		return err
 	}
-	kantraDir := filepath.Join(homeDir, ".kantra")
 	if err := os.MkdirAll(kantraDir, 0700); err != nil {
 		return err
 	}
@@ -265,11 +265,11 @@ func (l *loginCommand) storeTokens(loginResp *LoginResponse) error {
 }
 
 func loadStoredTokens() (*LoginResponse, error) {
-	homeDir, err := os.UserHomeDir()
+	kantraDir, err := util.GetKantraDir()
 	if err != nil {
 		return nil, err
 	}
-	tokenFile := filepath.Join(homeDir, ".kantra", "auth.json")
+	tokenFile := filepath.Join(kantraDir, "auth.json")
 	data, err := os.ReadFile(tokenFile)
 	if err != nil {
 		if os.IsNotExist(err) {

--- a/cmd/internal/settings/settings.go
+++ b/cmd/internal/settings/settings.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/codingconcepts/env"
+	"github.com/konveyor-ecosystem/kantra/pkg/util"
 )
 
 // Build-time variables set via ldflags.
@@ -15,12 +16,16 @@ import (
 // Example:
 //
 //	--ldflags="-X 'github.com/konveyor-ecosystem/kantra/cmd/internal/settings.Version=1.2.3' \
-//	           -X 'github.com/konveyor-ecosystem/kantra/cmd/internal/settings.BuildCommit=$(git rev-parse HEAD)'"
+//	           -X 'github.com/konveyor-ecosystem/kantra/cmd/internal/settings.BuildCommit=$(git rev-parse HEAD)' \
+//	           -X 'github.com/konveyor-ecosystem/kantra/cmd/internal/settings.ConfigDirName=mytool'"
 var (
 	BuildCommit = ""
 	Version     = "latest"
 
-	RootCommandName      = "kantra"
+	RootCommandName = "kantra"
+	// ConfigDirName is the basename (without leading dot) of the user config directory
+	// under $HOME or $XDG_CONFIG_HOME (e.g. "kantra" -> ~/.kantra). Override at build time.
+	ConfigDirName            = "kantra"
 	JavaBundlesLocation  = "/jdtls/java-analyzer-bundle/java-analyzer-bundle.core/target/java-analyzer-bundle.core-1.0.0-SNAPSHOT.jar"
 	JDTLSBinLocation     = "/jdtls/bin/jdtls"
 	MavenIndexPath       = "/usr/local/etc/maven-index.txt"
@@ -46,7 +51,22 @@ type Config struct {
 	CsharpProviderImage  string `env:"CSHARP_PROVIDER_IMG" default:"quay.io/konveyor/c-sharp-provider:latest"`
 }
 
+// ConfigDirBasename returns the dot-prefixed config directory name (from ConfigDirName).
+func ConfigDirBasename() string {
+	name := ConfigDirName
+	if name == "" {
+		name = "kantra"
+	}
+	if strings.HasPrefix(name, ".") {
+		return name
+	}
+	return "." + name
+}
+
 func (c *Config) Load() error {
+	if err := c.loadConfigDir(); err != nil {
+		return err
+	}
 	if err := c.loadCommandName(); err != nil {
 		return err
 	}
@@ -117,6 +137,11 @@ func (c *Config) loadRunnerImg() error {
 		return err
 	}
 
+	return nil
+}
+
+func (c *Config) loadConfigDir() error {
+	util.SetConfigDirBasename(ConfigDirBasename())
 	return nil
 }
 

--- a/cmd/internal/settings/settings_test.go
+++ b/cmd/internal/settings/settings_test.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"os/exec"
 	"testing"
+
+	"github.com/konveyor-ecosystem/kantra/pkg/util"
 )
 
 // Test RUNNER_IMG settings
@@ -186,6 +188,43 @@ func TestConfig_loadRunnerImg(t *testing.T) {
 				t.Errorf("Expected RUNNER_IMG=%s, got %s", tt.expectRunnerImg, os.Getenv("RUNNER_IMG"))
 			}
 		})
+	}
+}
+
+func TestConfigDirBasename(t *testing.T) {
+	orig := ConfigDirName
+	defer func() { ConfigDirName = orig }()
+
+	tests := []struct {
+		dirName string
+		want    string
+	}{
+		{dirName: "", want: ".kantra"},
+		{dirName: "kantra", want: ".kantra"},
+		{dirName: "mytool", want: ".mytool"},
+		{dirName: ".custom", want: ".custom"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.dirName, func(t *testing.T) {
+			ConfigDirName = tt.dirName
+			if got := ConfigDirBasename(); got != tt.want {
+				t.Errorf("ConfigDirBasename() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestConfig_loadConfigDir(t *testing.T) {
+	orig := ConfigDirName
+	defer func() { ConfigDirName = orig }()
+
+	ConfigDirName = "mytool"
+	c := &Config{}
+	if err := c.loadConfigDir(); err != nil {
+		t.Fatalf("loadConfigDir() error = %v", err)
+	}
+	if got := util.ConfigDirBasename(); got != ".mytool" {
+		t.Errorf("util.ConfigDirBasename() = %q, want %q", got, ".mytool")
 	}
 }
 

--- a/docs/developer.md
+++ b/docs/developer.md
@@ -12,9 +12,9 @@ The “kantra directory” is chosen in this order of priority:
 
 1. **`KANTRA_DIR`** — if the environment variable is set, that path is used.
 2. **Current working directory** — if it contains the subdirectories `rulesets`, `jdtls`, and `static-report`, it is used.
-3. **Config directory** — otherwise:
-   - Linux: `$XDG_CONFIG_HOME/.kantra` if `XDG_CONFIG_HOME` is set, else `$HOME/.kantra`
-   - macOS / Windows: `$HOME/.kantra` or `%USERPROFILE%\.kantra`
+3. **Config directory** — otherwise (default `~/.kantra`; distributors may set a different basename at **build time** via `settings.ConfigDirName` / ldflags):
+   - Linux: `$XDG_CONFIG_HOME/.<name>` if `XDG_CONFIG_HOME` is set, else `$HOME/.<name>`
+   - macOS / Windows: `$HOME/.<name>` or `%USERPROFILE%\.<name>`
 
 Setting `KANTRA_DIR` is useful when you run kantra from a different working directory (e.g. in scripts or when the process is started with a different `cwd`).
 

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -190,10 +190,29 @@ func ShouldFilterLine(line string) bool {
 
 const KantraDirEnv = "KANTRA_DIR"
 
+// configDirBasename is the dot-prefixed directory under $HOME / $XDG_CONFIG_HOME.
+// Default ".kantra"; distributors override at build time via settings.ConfigDirName.
+var configDirBasename = ".kantra"
+
+// SetConfigDirBasename sets the config directory basename used by GetKantraDir.
+// Called from settings.Load() with the build-time ConfigDirName value.
+func SetConfigDirBasename(basename string) {
+	if basename == "" {
+		configDirBasename = ".kantra"
+		return
+	}
+	configDirBasename = basename
+}
+
+// ConfigDirBasename returns the active dot-prefixed config directory name.
+func ConfigDirBasename() string {
+	return configDirBasename
+}
+
 // GetKantraDir returns the directory used for rulesets, jdtls, and static-report.
 // Resolution order: 1) KANTRA_DIR env var (if set), 2) current directory if it
-// contains "rulesets", "jdtls", and "static-report", 3) $HOME/.kantra (or
-// $XDG_CONFIG_HOME/.kantra on Linux when set).
+// contains "rulesets", "jdtls", and "static-report", 3) $HOME/<config dir> (or
+// $XDG_CONFIG_HOME/<config dir> on Linux when set; see ConfigDirBasename).
 func GetKantraDir() (string, error) {
 	var dir string
 	var err error
@@ -229,7 +248,7 @@ func GetKantraDir() (string, error) {
 	if set {
 		return dir, nil
 	}
-	// fall back to $HOME/.kantra
+	// fall back to config dir under $HOME or $XDG_CONFIG_HOME (Linux).
 	ops := runtime.GOOS
 	if ops == "linux" {
 		dir, set = os.LookupEnv("XDG_CONFIG_HOME")
@@ -241,5 +260,5 @@ func GetKantraDir() (string, error) {
 			return "", err
 		}
 	}
-	return filepath.Join(dir, ".kantra"), nil
+	return filepath.Join(dir, ConfigDirBasename()), nil
 }

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -282,6 +282,71 @@ func TestGetKantraDir_KANTRA_DIR_set(t *testing.T) {
 	}
 }
 
+func TestSetConfigDirBasename(t *testing.T) {
+	orig := ConfigDirBasename()
+	defer SetConfigDirBasename(orig)
+
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{name: "default empty", input: "", want: ".kantra"},
+		{name: "kantra", input: ".kantra", want: ".kantra"},
+		{name: "custom", input: ".mytool", want: ".mytool"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			SetConfigDirBasename(tt.input)
+			if got := ConfigDirBasename(); got != tt.want {
+				t.Errorf("ConfigDirBasename() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetKantraDir_configDirBasename(t *testing.T) {
+	origBasename := ConfigDirBasename()
+	origKantraDir := os.Getenv(KantraDirEnv)
+	origHome := os.Getenv("HOME")
+	origXDG := os.Getenv("XDG_CONFIG_HOME")
+	defer func() {
+		SetConfigDirBasename(origBasename)
+		if origKantraDir != "" {
+			os.Setenv(KantraDirEnv, origKantraDir)
+		} else {
+			os.Unsetenv(KantraDirEnv)
+		}
+		if origHome != "" {
+			os.Setenv("HOME", origHome)
+		} else {
+			os.Unsetenv("HOME")
+		}
+		if origXDG != "" {
+			os.Setenv("XDG_CONFIG_HOME", origXDG)
+		} else {
+			os.Unsetenv("XDG_CONFIG_HOME")
+		}
+	}()
+	os.Unsetenv(KantraDirEnv)
+	os.Unsetenv("XDG_CONFIG_HOME")
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	work := t.TempDir()
+	t.Chdir(work)
+
+	SetConfigDirBasename(".mytool")
+	got, err := GetKantraDir()
+	if err != nil {
+		t.Fatalf("GetKantraDir() error = %v", err)
+	}
+	want := filepath.Join(home, ".mytool")
+	if got != want {
+		t.Errorf("GetKantraDir() = %q, want %q", got, want)
+	}
+}
+
 func TestGetKantraDir_KANTRA_DIR_empty_unchanged_behavior(t *testing.T) {
 	orig := os.Getenv(KantraDirEnv)
 	defer func() {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that the config-directory basename is determined at build time and updated platform-specific config path examples.

* **Improvements**
  * Config-directory basename is build-time configurable and resolution now respects platform conventions (XDG/home/macOS/Windows).
  * Authentication now reads/writes tokens in the centralized config directory.

* **Tests**
  * Added tests covering configurable config-dir basename and its resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->