### PR TITLE
:bug: Check for kantra_dir in current binary directory, not in pwd

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ You can also use **Extract All** in File Explorer and choose `%USERPROFILE%\.kan
 
 1. Verify: `kantra version`
 
-Kantra resolves bundled assets in this order: `KANTRA_DIR` (if set) → current directory (when it contains `rulesets/`, `jdtls/`, and `static-report/`) → the default config directory: `$HOME/.kantra` on macOS, `%USERPROFILE%\.kantra` on Windows, and on Linux `$XDG_CONFIG_HOME/.kantra` when set or otherwise `$HOME/.kantra`. Containerless analysis requires those assets; hybrid and transform need the CLI and a container runtime (see [Prerequisites](#prerequisites)).
+Kantra resolves bundled assets in this order: `KANTRA_DIR` (if set) → binary directory (when it contains `rulesets/`, `jdtls/`, and `static-report/`) → the default config directory: `$HOME/.kantra` on macOS, `%USERPROFILE%\.kantra` on Windows, and on Linux `$XDG_CONFIG_HOME/.kantra` when set or otherwise `$HOME/.kantra`. Containerless analysis requires those assets; hybrid and transform need the CLI and a container runtime (see [Prerequisites](#prerequisites)).
 
 ### Build from source (development)
 

--- a/docs/containerless.md
+++ b/docs/containerless.md
@@ -18,8 +18,8 @@ Download appropriate zip for your OS [here](https://github.com/konveyor/kantra/r
 mv $HOME/kantra.<os>.<arch>/<os>-kantra /usr/local/bin
 ```
 
-### Move requirements to kantra known location, set `KANTRA_DIR`, or run kantra from the current directory:
-*Note:* kantra will first look for these requirements in `KANTRA_DIR`, then the current dir, and fall back to the path below.
+### Move requirements to kantra known location, set `KANTRA_DIR`, or place kantra binary alongside dependencies:
+*Note:* kantra will first look for these requirements in `KANTRA_DIR`, then the binary's directory, and fall back to the path below.
 
 
 ```sh

--- a/pkg/util/kantra_dir.go
+++ b/pkg/util/kantra_dir.go
@@ -8,7 +8,7 @@ import (
 )
 
 const kantraInstallHint = "Install containerless dependencies by extracting the kantra release archive into ~/.kantra, " +
-	"or run from a directory that contains rulesets/, jdtls/, and static-report/. " +
+	"or place the kantra binary in a directory that contains rulesets/, jdtls/, and static-report/. " +
 	"Set KANTRA_DIR to point at an existing installation directory."
 
 // MissingKantraDirectory returns an error when the kantra installation directory does not exist.

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -230,31 +230,29 @@ func GetKantraDir() (string, error) {
 		return filepath.Clean(envDir), nil
 	}
 
-	set := true
-	// check binary directory first for reqs
+	// check binary directory for reqs (if binary path is resolvable)
 	exePath, err := os.Executable()
-	if err != nil {
-		return "", err
+	if err == nil {
+		// resolve symlinks to get the actual binary location
+		exePath, err = filepath.EvalSymlinks(exePath)
 	}
-	// resolve symlinks to get the actual binary location
-	exePath, err = filepath.EvalSymlinks(exePath)
-	if err != nil {
-		return "", err
-	}
-	dir = filepath.Dir(exePath)
-
-	for _, v := range reqs {
-		_, err := os.Stat(filepath.Join(dir, v))
-		if err != nil {
-			set = false
-			break
+	if err == nil {
+		dir = filepath.Dir(exePath)
+		foundAll := true
+		for _, v := range reqs {
+			_, err := os.Stat(filepath.Join(dir, v))
+			if err != nil {
+				foundAll = false
+				break
+			}
+		}
+		// all reqs found here
+		if foundAll {
+			return dir, nil
 		}
 	}
-	// all reqs found here
-	if set {
-		return dir, nil
-	}
 	// fall back to config dir under $HOME or $XDG_CONFIG_HOME (Linux).
+	var set bool
 	ops := runtime.GOOS
 	if ops == "linux" {
 		dir, set = os.LookupEnv("XDG_CONFIG_HOME")

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -209,7 +209,7 @@ func ConfigDirBasename() string {
 }
 
 // GetKantraDir returns the directory used for rulesets, jdtls, and static-report.
-// Resolution order: 1) KANTRA_DIR env var (if set), 2) current directory if it
+// Resolution order: 1) KANTRA_DIR env var (if set), 2) binary directory if it
 // contains "rulesets", "jdtls", and "static-report", 3) $HOME/<config dir> (or
 // $XDG_CONFIG_HOME/<config dir> on Linux when set; see ConfigDirBasename).
 func GetKantraDir() (string, error) {
@@ -231,11 +231,18 @@ func GetKantraDir() (string, error) {
 	}
 
 	set := true
-	// check current dir first for reqs
-	dir, err = os.Getwd()
+	// check binary directory first for reqs
+	exePath, err := os.Executable()
 	if err != nil {
 		return "", err
 	}
+	// resolve symlinks to get the actual binary location
+	exePath, err = filepath.EvalSymlinks(exePath)
+	if err != nil {
+		return "", err
+	}
+	dir = filepath.Dir(exePath)
+
 	for _, v := range reqs {
 		_, err := os.Stat(filepath.Join(dir, v))
 		if err != nil {

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -358,7 +358,7 @@ func TestGetKantraDir_KANTRA_DIR_empty_unchanged_behavior(t *testing.T) {
 	}()
 	os.Unsetenv(KantraDirEnv)
 
-	// When KANTRA_DIR is unset, we get either cwd (if reqs present) or home/.kantra.
+	// When KANTRA_DIR is unset, we get either binary dir (if reqs present) or home/.kantra.
 	// We only assert we get a non-empty path and no error.
 	got, err := GetKantraDir()
 	if err != nil {


### PR DESCRIPTION
Fixes https://github.com/konveyor/kantra/issues/815

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Asset resolution now prefers the application binary’s directory for bundled resources before falling back to the config directory when no override is set.

* **Documentation**
  * Updated installation and containerless guidance to reflect the new lookup order and provide revised installation hints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->