### PR TITLE
Error if no hub profile found

### DIFF
--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -183,24 +183,7 @@ func NewSyncCmd(log logr.Logger) *cobra.Command {
 			if insecure, err := cmd.Parent().PersistentFlags().GetBool("insecure"); err == nil {
 				syncCmd.insecure = insecure
 			}
-			application, err := syncCmd.getApplicationFromHub()
-			if err != nil {
-				log.Error(err, "failed to get application from Hub")
-				return err
-			}
-			profiles, err := syncCmd.getProfilesFromHubApplication(int(application.ID))
-			if err != nil {
-				return err
-			}
-			for _, profile := range profiles {
-				log.Info("downloading profile", "name", profile.Name, "ID", profile.ID)
-				err = syncCmd.downloadProfileBundle(int(profile.ID))
-				if err != nil {
-					log.Error(err, "failed to download profile bundle", "profileID", profile.ID, "profileName", profile.Name)
-					return err
-				}
-			}
-			return nil
+			return syncCmd.sync()
 		},
 	}
 
@@ -211,6 +194,31 @@ func NewSyncCmd(log logr.Logger) *cobra.Command {
 	syncCommand.Flags().StringVar(&syncCmd.host, "host", "", "Hub base URL for unauthenticated instances (skips stored PAT login)")
 
 	return syncCommand
+}
+
+func (s *syncCommand) sync() error {
+	application, err := s.getApplicationFromHub()
+	if err != nil {
+		s.log.Error(err, "failed to get application from Hub")
+		return err
+	}
+
+	profiles, err := s.getProfilesFromHubApplication(int(application.ID))
+	if err != nil {
+		return err
+	}
+	if len(profiles) == 0 {
+		return fmt.Errorf("no analysis profiles found in Hub for application %q (ID %d); create a profile in the Hub before syncing", application.Name, application.ID)
+	}
+
+	for _, profile := range profiles {
+		s.log.Info("downloading profile", "name", profile.Name, "ID", profile.ID)
+		if err := s.downloadProfileBundle(int(profile.ID)); err != nil {
+			s.log.Error(err, "failed to download profile bundle", "profileID", profile.ID, "profileName", profile.Name)
+			return err
+		}
+	}
+	return nil
 }
 
 func (s *syncCommand) Validate(ctx context.Context) error {

--- a/cmd/config/config_test.go
+++ b/cmd/config/config_test.go
@@ -923,6 +923,53 @@ func TestSyncCommand_getProfilesFromHubApplication(t *testing.T) {
 	}
 }
 
+func TestSyncCommand_sync_noProfiles(t *testing.T) {
+	log := logr.Discard()
+	setupTempAuth(t, &AuthConfig{Host: "http://test-host", Token: testPAT})
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case hubAPIPath(hubapi.ApplicationsRoute):
+			apps := []hubapi.Application{
+				{
+					Resource: hubapi.Resource{ID: 1},
+					Name:     "book-server",
+					Repository: &hubapi.Repository{
+						URL: "https://github.com/ibraginsky/book-server.git",
+					},
+				},
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(apps)
+		case "/hub/applications/1/analysis/profiles":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode([]hubapi.AnalysisProfile{})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	tmpDir := t.TempDir()
+	syncCmd := &syncCommand{
+		log:             log,
+		url:             "https://github.com/ibraginsky/book-server.git",
+		applicationPath: tmpDir,
+		hubClient:       mustTestHubClient(t, server.URL, testPAT),
+	}
+
+	err := syncCmd.sync()
+	if err == nil {
+		t.Fatal("sync() expected error when Hub returns no profiles")
+	}
+	if !strings.Contains(err.Error(), "no analysis profiles found") {
+		t.Errorf("sync() error = %v, want message about missing profiles", err)
+	}
+	if !strings.Contains(err.Error(), "book-server") {
+		t.Errorf("sync() error = %v, want application name in message", err)
+	}
+}
+
 func TestHubClient_downloadProfileBundle(t *testing.T) {
 	log := logr.Discard()
 


### PR DESCRIPTION
Fixes #845 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling during profile synchronization - the sync command now returns explicit error messages when no analysis profiles are found, improving user feedback.

* **Tests**
  * Added test coverage to verify proper error handling when profile synchronization is attempted with zero available profiles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->