### PR TITLE
Add analysis mode to rules test

### DIFF
--- a/cmd/rules/test/runner.go
+++ b/cmd/rules/test/runner.go
@@ -14,6 +14,7 @@ import (
 	"github.com/konveyor-ecosystem/kantra/pkg/util"
 	konveyorAnalyzer "github.com/konveyor/analyzer-lsp/core"
 	"github.com/konveyor/analyzer-lsp/output/v1/konveyor"
+	"github.com/konveyor/analyzer-lsp/provider"
 	"github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v2"
 )
@@ -38,6 +39,9 @@ type TestOptions struct {
 	// RunLocal runs Java and builtin in containerless mode on the host (analyze --run-local).
 	// Requires ValidateContainerlessProviders to have succeeded.
 	RunLocal bool
+
+	// Mode is the default analysis mode for test cases that omit analysisParams.mode.
+	Mode string
 
 	// ContainerBinary is the path to the container runtime (podman/docker).
 	ContainerBinary string
@@ -225,6 +229,8 @@ func runWithEnvironment(logger logr.Logger, opts TestOptions, testsFile TestsFil
 		return "", fmt.Errorf("failed to create output directory: %w", err)
 	}
 
+	analysisParams = resolveAnalysisParams(opts.Mode, analysisParams)
+
 	var providerInfos []kantraprovider.ProviderInfo
 	if !opts.RunLocal {
 		providerInfos = buildTestProviderInfos(testsFile.Providers, opts.ProviderImages)
@@ -384,10 +390,26 @@ func buildReproducerCmd(runLocal bool, input string, outputDir string, rulesPath
 		"--rules", rulesPath,
 		"--overwrite", "--enable-default-rulesets=false",
 	)
+	if params.Mode != "" {
+		args = append(args, "--mode", string(params.Mode))
+	}
 	if params.DepLabelSelector != "" {
 		args = append(args, "--label-selector", params.DepLabelSelector)
 	}
 	return fmt.Sprintf("kantra %s", strings.Join(args, " "))
+}
+
+func resolveAnalysisParams(defaultMode string, params AnalysisParams) AnalysisParams {
+	if params.Mode != "" {
+		return params
+	}
+	if defaultMode == "" {
+		return params
+	}
+	return AnalysisParams{
+		Mode:             provider.AnalysisMode(defaultMode),
+		DepLabelSelector: params.DepLabelSelector,
+	}
 }
 
 func ensureRules(rulesPath string, tempDirPath string, group []Test) error {

--- a/cmd/rules/test/test_cmd_test.go
+++ b/cmd/rules/test/test_cmd_test.go
@@ -286,3 +286,34 @@ func TestTestCommand_Validation(t *testing.T) {
 		t.Logf("Expected error for non-existent file: %v", err)
 	}
 }
+
+func TestResolveTestCommandMode(t *testing.T) {
+	t.Run("defaults to source-only", func(t *testing.T) {
+		mode, err := resolveTestCommandMode("")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if mode != "source-only" {
+			t.Errorf("expected source-only, got %q", mode)
+		}
+	})
+
+	t.Run("accepts explicit modes", func(t *testing.T) {
+		for _, want := range []string{"full", "source-only"} {
+			mode, err := resolveTestCommandMode(want)
+			if err != nil {
+				t.Fatalf("mode %q: unexpected error: %v", want, err)
+			}
+			if mode != want {
+				t.Errorf("mode %q: got %q", want, mode)
+			}
+		}
+	})
+
+	t.Run("rejects invalid mode", func(t *testing.T) {
+		_, err := resolveTestCommandMode("invalid")
+		if err == nil {
+			t.Fatal("expected error for invalid mode")
+		}
+	})
+}

--- a/cmd/rules/test/test_cmd_test.go
+++ b/cmd/rules/test/test_cmd_test.go
@@ -52,6 +52,7 @@ func TestTestCommand_Flags(t *testing.T) {
 		"test-filter",
 		"prune",
 		"run-local",
+		"mode",
 	}
 
 	for _, flagName := range expectedFlags {

--- a/cmd/rules/test/yaml_rule_test_cmd.go
+++ b/cmd/rules/test/yaml_rule_test_cmd.go
@@ -50,7 +50,7 @@ func NewTestCommand(log logr.Logger) *cobra.Command {
 					return err
 				}
 			}
-			mode, err := resolveTestCommandMode(testCmd.mode, testCmd.runLocal)
+			mode, err := resolveTestCommandMode(testCmd.mode)
 			if err != nil {
 				log.Error(err, "invalid analysis mode")
 				return err
@@ -87,16 +87,13 @@ func NewTestCommand(log logr.Logger) *cobra.Command {
 	testCobraCommand.Flags().BoolVar(&testCmd.runLocal, "run-local", false,
 		"run Java and builtin providers on the host (containerless); default is hybrid mode (providers in containers), required for Go, Python, Node.js, and C# tests")
 	testCobraCommand.Flags().StringVarP(&testCmd.mode, "mode", "m", "",
-		"analysis mode. Must be one of 'full' (source + dependencies) or 'source-only'.")
+		"analysis mode. Must be one of 'full' (source + dependencies) or 'source-only' (default).")
 	return testCobraCommand
 }
 
-func resolveTestCommandMode(mode string, runLocal bool) (string, error) {
+func resolveTestCommandMode(mode string) (string, error) {
 	if mode == "" {
-		if runLocal {
-			return string(provider.SourceOnlyAnalysisMode), nil
-		}
-		return string(provider.FullAnalysisMode), nil
+		return string(provider.SourceOnlyAnalysisMode), nil
 	}
 	if mode != string(provider.FullAnalysisMode) &&
 		mode != string(provider.SourceOnlyAnalysisMode) {

--- a/cmd/rules/test/yaml_rule_test_cmd.go
+++ b/cmd/rules/test/yaml_rule_test_cmd.go
@@ -1,10 +1,12 @@
 package test
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/go-logr/logr"
 	"github.com/konveyor-ecosystem/kantra/cmd/internal/settings"
+	"github.com/konveyor/analyzer-lsp/provider"
 	"github.com/spf13/cobra"
 )
 
@@ -12,6 +14,7 @@ type testCommand struct {
 	testFilterString string
 	prune            bool
 	runLocal         bool
+	mode             string
 }
 
 func NewTestCommand(log logr.Logger) *cobra.Command {
@@ -47,9 +50,15 @@ func NewTestCommand(log logr.Logger) *cobra.Command {
 					return err
 				}
 			}
+			mode, err := resolveTestCommandMode(testCmd.mode, testCmd.runLocal)
+			if err != nil {
+				log.Error(err, "invalid analysis mode")
+				return err
+			}
 			results, err := NewRunner().Run(tests, TestOptions{
 				Context:         cmd.Context(),
 				RunLocal:        testCmd.runLocal,
+				Mode:            mode,
 				ContainerBinary: settings.Settings.ContainerBinary,
 				ProviderImages: map[string]string{
 					"java":   settings.Settings.JavaProviderImage,
@@ -77,5 +86,21 @@ func NewTestCommand(log logr.Logger) *cobra.Command {
 	testCobraCommand.Flags().BoolVarP(&testCmd.prune, "prune", "p", false, "whether to prune after the execution; defaults to false")
 	testCobraCommand.Flags().BoolVar(&testCmd.runLocal, "run-local", false,
 		"run Java and builtin providers on the host (containerless); default is hybrid mode (providers in containers), required for Go, Python, Node.js, and C# tests")
+	testCobraCommand.Flags().StringVarP(&testCmd.mode, "mode", "m", "",
+		"analysis mode. Must be one of 'full' (source + dependencies) or 'source-only'.")
 	return testCobraCommand
+}
+
+func resolveTestCommandMode(mode string, runLocal bool) (string, error) {
+	if mode == "" {
+		if runLocal {
+			return string(provider.SourceOnlyAnalysisMode), nil
+		}
+		return string(provider.FullAnalysisMode), nil
+	}
+	if mode != string(provider.FullAnalysisMode) &&
+		mode != string(provider.SourceOnlyAnalysisMode) {
+		return "", fmt.Errorf("mode must be one of 'full' or 'source-only'")
+	}
+	return mode, nil
 }


### PR DESCRIPTION
Fixes #837 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--mode/-m` flag to the test command to select the analysis mode.
  * Test executions now default analysis mode automatically when a test case omits its own mode, while still honoring any per-test overrides.
  * Reproducer generation now includes the mode option only when a mode is explicitly resolved.
* **Tests**
  * Updated flag expectations and added coverage for mode validation and defaulting behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->