### PR TITLE
Fix profile validation & windows progress bar

### DIFF
--- a/cmd/analyze/containerless.go
+++ b/cmd/analyze/containerless.go
@@ -37,12 +37,7 @@ func (hook *ConsoleHook) Levels() []logrus.Level {
 
 // renderProgressBar renders a visual progress bar to stderr
 func renderProgressBar(percent int, current, total int, message string) {
-	const barWidth = 25
-	filled := (percent * barWidth) / 100
-	if filled > barWidth {
-		filled = barWidth
-	}
-	bar := strings.Repeat("█", filled) + strings.Repeat("░", barWidth-filled)
+	bar := buildProgressBar(percent)
 
 	// Truncate message if too long
 	maxMessageLen := 40
@@ -50,9 +45,8 @@ func renderProgressBar(percent int, current, total int, message string) {
 		message = message[:maxMessageLen-3] + "..."
 	}
 
-	// Use \r to return to start of line and \033[K to clear to end of line
-	fmt.Fprintf(os.Stderr, "\r\033[K  ✓ Processing rules %3d%% |%s| %d/%d  %s",
-		percent, bar, current, total, message)
+	fmt.Fprintf(os.Stderr, "%s%sProcessing rules %3d%% |%s| %d/%d  %s",
+		progressLinePrefix(), progressStatusPrefix(), percent, bar, current, total, message)
 }
 
 func (a *analyzeCommand) buildStaticReportFile(ctx context.Context, staticReportPath string, depsErr bool) error {

--- a/cmd/analyze/containerless_helpers_test.go
+++ b/cmd/analyze/containerless_helpers_test.go
@@ -3,7 +3,6 @@ package analyze
 import (
 	"bytes"
 	"os"
-	"strings"
 	"testing"
 
 	"github.com/go-logr/logr/testr"
@@ -99,8 +98,8 @@ func Test_renderProgressBar_ContainsProgressBarChars(t *testing.T) {
 	os.Stderr = oldStderr
 
 	output := buf.String()
-	assert.True(t, strings.Contains(output, "█"), "progress bar should contain filled character")
-	assert.True(t, strings.Contains(output, "░"), "progress bar should contain empty character")
+	bar := buildProgressBar(50)
+	assert.Contains(t, output, bar)
 }
 
 func TestConsoleHook_Fire(t *testing.T) {

--- a/cmd/analyze/progress.go
+++ b/cmd/analyze/progress.go
@@ -3,9 +3,45 @@ package analyze
 import (
 	"fmt"
 	"os"
+	"runtime"
+	"strings"
 
 	"github.com/go-logr/logr"
 )
+
+const progressBarWidth = 25
+
+func progressCheckMark() string {
+	if runtime.GOOS == "windows" {
+		return "+"
+	}
+	return "✓"
+}
+
+func buildProgressBar(percent int) string {
+	filled := (percent * progressBarWidth) / 100
+	if filled > progressBarWidth {
+		filled = progressBarWidth
+	}
+
+	filledChar, emptyChar := "█", "░"
+	if runtime.GOOS == "windows" {
+		filledChar, emptyChar = "#", "-"
+	}
+
+	return strings.Repeat(filledChar, filled) + strings.Repeat(emptyChar, progressBarWidth-filled)
+}
+
+func progressLinePrefix() string {
+	if runtime.GOOS == "windows" {
+		return "\r"
+	}
+	return "\r\033[K"
+}
+
+func progressStatusPrefix() string {
+	return fmt.Sprintf("  %s ", progressCheckMark())
+}
 
 // ProgressMode encapsulates progress reporting behavior.
 // It provides methods to conditionally execute UI operations based on whether

--- a/cmd/analyze/progress_test.go
+++ b/cmd/analyze/progress_test.go
@@ -3,7 +3,10 @@ package analyze
 import (
 	"bytes"
 	"os"
+	"runtime"
+	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/go-logr/logr/testr"
 	"github.com/stretchr/testify/assert"
@@ -313,5 +316,35 @@ func TestProgressMode_Println(t *testing.T) {
 
 			assert.Equal(t, tt.wantOutput, buf.String())
 		})
+	}
+}
+
+func Test_buildProgressBar(t *testing.T) {
+	bar := buildProgressBar(50)
+	assert.Equal(t, progressBarWidth, utf8.RuneCountInString(bar))
+
+	if runtime.GOOS == "windows" {
+		assert.True(t, strings.Contains(bar, "#"))
+		assert.True(t, strings.Contains(bar, "-"))
+		assert.False(t, strings.Contains(bar, "█"))
+	} else {
+		assert.True(t, strings.Contains(bar, "█"))
+		assert.True(t, strings.Contains(bar, "░"))
+	}
+}
+
+func Test_progressCheckMark(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		assert.Equal(t, "+", progressCheckMark())
+	} else {
+		assert.Equal(t, "✓", progressCheckMark())
+	}
+}
+
+func Test_progressStatusPrefix(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		assert.Equal(t, "  + ", progressStatusPrefix())
+	} else {
+		assert.Equal(t, "  ✓ ", progressStatusPrefix())
 	}
 }

--- a/cmd/analyze/providers.go
+++ b/cmd/analyze/providers.go
@@ -79,26 +79,20 @@ func setupProgressReporter(ctx context.Context, noProgress bool) (
 					// Display provider preparation progress
 					if event.Total > 0 {
 						percent := (event.Current * 100) / event.Total
-						const barWidth = 25
-						filled := (percent * barWidth) / 100
-						if filled > barWidth {
-							filled = barWidth
-						}
-						bar := strings.Repeat("█", filled) + strings.Repeat("░", barWidth-filled)
-						// Use \r to return to start of line and \033[K to clear to end of line
-						fmt.Fprintf(os.Stderr, "\r\033[K  ✓ %s %3d%% |%s| %d/%d files",
-							event.Message, percent, bar, event.Current, event.Total)
+						bar := buildProgressBar(percent)
+						fmt.Fprintf(os.Stderr, "%s%s%s %3d%% |%s| %d/%d files",
+							progressLinePrefix(), progressStatusPrefix(), event.Message, percent, bar, event.Current, event.Total)
 						// Print newline when prepare progress reaches 100%
 						if event.Current >= event.Total {
 							fmt.Fprintf(os.Stderr, "\n")
 						}
 					}
 				case progress.StageDependencyResolution:
-					fmt.Fprintf(os.Stderr, "  ✓ Resolved %d dependencies\n", event.Total)
+					fmt.Fprintf(os.Stderr, "%sResolved %d dependencies\n", progressStatusPrefix(), event.Total)
 				case progress.StageRuleParsing:
 					if event.Total > 0 {
 						cumulativeTotal += event.Total
-						fmt.Fprintf(os.Stderr, "  ✓ Loaded %d rules\n", cumulativeTotal)
+						fmt.Fprintf(os.Stderr, "%sLoaded %d rules\n", progressStatusPrefix(), cumulativeTotal)
 						justPrintedLoadedRules = true
 					}
 				case progress.StageRuleExecution:
@@ -106,7 +100,7 @@ func setupProgressReporter(ctx context.Context, noProgress bool) (
 						// Initialize cumulativeTotal from first event if not set by rule parsing
 						if cumulativeTotal == 0 {
 							cumulativeTotal = event.Total
-							fmt.Fprintf(os.Stderr, "  ✓ Loaded %d rules\n", cumulativeTotal)
+							fmt.Fprintf(os.Stderr, "%sLoaded %d rules\n", progressStatusPrefix(), cumulativeTotal)
 							justPrintedLoadedRules = true
 						}
 

--- a/cmd/analyze/run.go
+++ b/cmd/analyze/run.go
@@ -169,7 +169,7 @@ func (a *analyzeCommand) runAnalysis(ctx context.Context, cmd *cobra.Command, mo
 		return err
 	}
 	defer env.Stop(ctx)
-	progressMode.Printf("  ✓ Started providers\n")
+	progressMode.Printf("%sStarted providers\n", progressStatusPrefix())
 
 	// --- Provider configs + overrides ---
 	providerConfigs := env.ProviderConfigs()
@@ -265,9 +265,9 @@ func (a *analyzeCommand) runAnalysis(ctx context.Context, cmd *cobra.Command, mo
 	operationalLog.Info("[TIMING] Analyzer created", "duration_ms", time.Since(startAnalyzer).Milliseconds())
 
 	if isBinaryAnalysis {
-		progressMode.Printf("  ✓ Decompiling complete\n")
+		progressMode.Printf("%sDecompiling complete\n", progressStatusPrefix())
 	}
-	progressMode.Printf("  ✓ Initialized providers\n")
+	progressMode.Printf("%sInitialized providers\n", progressStatusPrefix())
 
 	// Parse rules
 	startRuleLoading := time.Now()
@@ -289,7 +289,7 @@ func (a *analyzeCommand) runAnalysis(ctx context.Context, cmd *cobra.Command, mo
 	}
 	operationalLog.Info("[TIMING] Provider init complete", "duration_ms", time.Since(startProviders).Milliseconds())
 
-	progressMode.Printf("  ✓ Started rules engine\n")
+	progressMode.Printf("%sStarted rules engine\n", progressStatusPrefix())
 
 	// Run analysis
 	startRuleExecution := time.Now()

--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -88,6 +88,9 @@ func NewListCmd(log logr.Logger) *cobra.Command {
 		Use:   "list",
 		Short: "List local Hub profiles in the application",
 		PreRunE: func(cmd *cobra.Command, args []string) error {
+			if err := cmd.ValidateRequiredFlags(); err != nil {
+				return err
+			}
 			err := listCmd.Validate(cmd.Context())
 			if err != nil {
 				log.Error(err, "failed to validate flags")
@@ -108,18 +111,15 @@ func NewListCmd(log logr.Logger) *cobra.Command {
 		},
 	}
 
-	listCommand.Flags().StringVar(&listCmd.profileDir, "profile-dir", "", "application directory path to look for profiles. Default is the current directory")
+	listCommand.Flags().StringVar(&listCmd.profileDir, "profile-dir", "", "application directory path to look for profiles")
+	listCommand.MarkFlagRequired("profile-dir")
 
 	return listCommand
 }
 
 func (l *listCommand) Validate(ctx context.Context) error {
 	if l.profileDir == "" {
-		currentDir, err := os.Getwd()
-		if err != nil {
-			return err
-		}
-		l.profileDir = currentDir
+		return fmt.Errorf("--profile-dir is required")
 	}
 
 	stat, err := os.Stat(l.profileDir)
@@ -130,7 +130,10 @@ func (l *listCommand) Validate(ctx context.Context) error {
 		return fmt.Errorf("application path for profile %s is not a directory", l.profileDir)
 	}
 	profilesDir := filepath.Join(l.profileDir, profile.Profiles)
-	if _, err := os.Stat(profilesDir); os.IsNotExist(err) {
+	if _, err := os.Stat(profilesDir); err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("profiles directory not found at %s", profilesDir)
+		}
 		return err
 	}
 	return nil

--- a/cmd/config/config_test.go
+++ b/cmd/config/config_test.go
@@ -146,21 +146,12 @@ func TestListCommand_Validate(t *testing.T) {
 		errMsg    string
 	}{
 		{
-			name: "empty profile-dir should use current directory",
+			name: "empty profile-dir should fail",
 			setupFunc: func() (string, func(), error) {
-				// Create profiles directory in current working directory for test
-				currentDir, err := os.Getwd()
-				if err != nil {
-					return "", nil, err
-				}
-				profilesDir := filepath.Join(currentDir, profile.Profiles)
-				err = os.MkdirAll(profilesDir, 0755)
-				if err != nil {
-					return "", nil, err
-				}
-				return "", func() { os.RemoveAll(profilesDir) }, nil
+				return "", func() {}, nil
 			},
-			wantErr: false,
+			wantErr: true,
+			errMsg:  "--profile-dir is required",
 		},
 		{
 			name: "valid directory with profiles should pass",
@@ -215,7 +206,7 @@ func TestListCommand_Validate(t *testing.T) {
 				return tmpDir, func() { os.RemoveAll(tmpDir) }, nil
 			},
 			wantErr: true,
-			errMsg:  "no such file or directory",
+			errMsg:  "profiles directory not found",
 		},
 	}
 
@@ -1399,34 +1390,16 @@ func TestConfigCommandIntegration(t *testing.T) {
 		}
 	})
 
-	t.Run("config list subcommand without profile-dir flag (uses current directory)", func(t *testing.T) {
-		// Create profiles directory in current working directory for test
-		currentDir, err := os.Getwd()
-		if err != nil {
-			t.Fatalf("Failed to get current directory: %v", err)
-		}
-
-		profilesDir := filepath.Join(currentDir, profile.Profiles)
-		err = os.MkdirAll(profilesDir, 0755)
-		if err != nil {
-			t.Fatalf("Failed to create profiles dir: %v", err)
-		}
-		defer os.RemoveAll(profilesDir)
-
-		profileDirs := []string{"profile1", "profile2"}
-		for _, dir := range profileDirs {
-			err = os.MkdirAll(filepath.Join(profilesDir, dir), 0755)
-			if err != nil {
-				t.Fatalf("Failed to create profile dir: %v", err)
-			}
-		}
-
+	t.Run("config list subcommand without profile-dir flag should fail", func(t *testing.T) {
 		cmd := NewConfigCmd(log)
 		cmd.SetArgs([]string{"list"})
 
-		err = cmd.Execute()
-		if err != nil {
-			t.Errorf("Command execution failed: %v", err)
+		err := cmd.Execute()
+		if err == nil {
+			t.Fatal("Expected command execution to fail without --profile-dir")
+		}
+		if !strings.Contains(err.Error(), `required flag(s) "profile-dir" not set`) {
+			t.Errorf("Expected required flag error, got: %v", err)
 		}
 	})
 }


### PR DESCRIPTION
Fixes #843 
Fixes #741 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * `config list` command now requires the `--profile-dir` flag to be explicitly specified instead of defaulting to the current directory.

* **Improvements**
  * Progress bar rendering now provides improved cross-platform terminal output formatting and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->