### PR TITLE
:sparkles: Print deprecation warning on openrewrite

### DIFF
--- a/cmd/openrewrite/openrewrite.go
+++ b/cmd/openrewrite/openrewrite.go
@@ -46,6 +46,9 @@ func NewOpenRewriteCommand(log logr.Logger) *cobra.Command {
 
 		Short: "Transform application source code using OpenRewrite recipes",
 		PreRun: func(cmd *cobra.Command, args []string) {
+			// Print deprecation warning
+			fmt.Fprintf(cmd.ErrOrStderr(), "WARNING: The 'openrewrite' command is deprecated and will be removed in a future version.\n\n")
+
 			if !cmd.Flags().Lookup("list-targets").Changed {
 				cmd.MarkFlagRequired("input")
 				cmd.MarkFlagRequired("target")

--- a/cmd/openrewrite/openrewrite_test.go
+++ b/cmd/openrewrite/openrewrite_test.go
@@ -332,3 +332,32 @@ func TestOpenRewriteCommand_WithRootCommand(t *testing.T) {
 		t.Error("OpenRewrite command was not found as a child of root command")
 	}
 }
+
+func TestOpenRewriteCommand_DeprecationWarning(t *testing.T) {
+	testLogger := logrus.New()
+	logger := logrusr.New(testLogger)
+
+	cmd := NewOpenRewriteCommand(logger)
+
+	// Create a buffer to capture stderr
+	buf := &bytes.Buffer{}
+	cmd.SetErr(buf)
+	cmd.SetOut(buf)
+
+	// Set the list-targets flag to avoid validation errors
+	cmd.SetArgs([]string{"--list-targets"})
+
+	// Execute the command
+	err := cmd.Execute()
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	// Check that the deprecation warning was printed
+	output := buf.String()
+	expectedWarning := "WARNING: The 'openrewrite' command is deprecated and will be removed in a future version."
+
+	if !bytes.Contains(buf.Bytes(), []byte(expectedWarning)) {
+		t.Errorf("Expected deprecation warning in output.\nGot: %s", output)
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/konveyor/kantra/issues/853

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * The `openrewrite` command now displays a deprecation warning when executed, informing users that this command will be removed in a future version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->